### PR TITLE
Add auto-generated artefacts to exclusion list

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,9 @@
 *_out.nc
 config_*.nam
 *_sza.nc
+mod/
+driver/test_spartacus_math
+bin/ecrad
+practical/ecrad
+practical/data
+test/ifs/inputs.nc


### PR DESCRIPTION
These compile-time generated folders/files are currently being tracked. This PR removes them by adding them to `.gitignore`.