### PR TITLE
Compile-time ng in ecCKD and TripleClouds + GPTL timing library

### DIFF
--- a/Makefile_include.intel_atos
+++ b/Makefile_include.intel_atos
@@ -38,3 +38,6 @@ BASICFLAGS = -module ../mod -fpe0 -assume byterecl -align array64byte \
 	   -finline-functions -finline-limit=1500 -Winline -assume realloc_lhs
 DEBUGFLAGS = -g
 OMPFLAG = -qopenmp -qopenmp-threadprivate=compat
+
+# location of General Purpose Timing Library (compile with GPTL_TIMING=1 or GPTL_TIMING=2)
+TIME_DIR=/home/papu/gptl-ifort

--- a/radiation/ecrad_config.h
+++ b/radiation/ecrad_config.h
@@ -37,3 +37,15 @@
 ! tasks. The MPI version is not used for writing files.
 
 !#define EASY_NETCDF_READ_MPI 1
+
+! Allow size of inner dimension (number of g-points) to be known at compile time if NG_LW/NG_SW is defined
+#ifdef NG_LW
+  integer, parameter :: ng_lw = NG_LW
+#else
+#define ng_lw ng_lw_in
+#endif
+#ifdef NG_SW
+  integer, parameter :: ng_sw = NG_SW
+#else
+#define ng_sw ng_sw_in
+#endif

--- a/radiation/ecrad_definitions.F90
+++ b/radiation/ecrad_definitions.F90
@@ -1,0 +1,22 @@
+module ecrad_definitions
+
+  use parkind1, only : jpim
+
+  implicit none
+
+  ! By making the number of regions a parameter NREGION, the compiler
+  ! can optimize better.  We also provide a preprocessor parameter as
+  ! in one or two cases the operations on 2x2 and 3x3 matrices
+  ! (e.g. matrix exponentials) are completely different algorithms.
+#define NUM_REGIONS 2
+  integer(jpim), parameter :: NREGION = NUM_REGIONS
+
+! Allow size of inner dimension (number of g-points) to be known at compile time if NG_LW is defined
+#ifdef NG_LW
+  integer(jpim), parameter :: ng_lw = NG_LW
+#else
+#define ng_lw ng_lw_in
+#endif
+
+
+end module ecrad_definitions

--- a/radiation/radiation_aerosol_optics.F90
+++ b/radiation/radiation_aerosol_optics.F90
@@ -18,12 +18,11 @@
 !   2022-03-27  R. Hogan  Add setup_general_aerosol_optics_legacy to use RRTM aerosol files with ecCKD
 !   2022-11-22  P. Ukkonen / R. Hogan  Optimizations to enhance vectorization
 
-#include "ecrad_config.h"
-
 module radiation_aerosol_optics
 
   implicit none
   public
+#include "ecrad_config.h"
 
 contains
 

--- a/radiation/radiation_aerosol_optics_data.F90
+++ b/radiation/radiation_aerosol_optics_data.F90
@@ -16,8 +16,6 @@
 !   2017-10-23  R. Hogan  Renamed single-character variables
 !   2018-04-20  A. Bozzo  Read optical properties at selected wavelengths
 
-#include "ecrad_config.h"
-
 module radiation_aerosol_optics_data
 
   use parkind1,      only : jprb
@@ -27,6 +25,8 @@ module radiation_aerosol_optics_data
   public
 
   private :: get_line
+
+#include "ecrad_config.h"
 
   ! The following provide possible values for
   ! aerosol_optics_type%iclass, which is used to map the user's type

--- a/radiation/radiation_aerosol_optics_description.F90
+++ b/radiation/radiation_aerosol_optics_description.F90
@@ -13,14 +13,14 @@
 ! Email:   r.j.hogan@ecmwf.int
 !
 
-#include "ecrad_config.h"
-
 module radiation_aerosol_optics_description
 
   use parkind1,      only : jprb
 
   implicit none
   public
+
+#include "ecrad_config.h"
 
   !---------------------------------------------------------------------
   ! This type holds the metadata from an aerosol optical property

--- a/radiation/radiation_cloud_cover.F90
+++ b/radiation/radiation_cloud_cover.F90
@@ -18,13 +18,13 @@
 ! Modifications
 !   2020-10-07  R. Hogan  Ensure iobj1 initialized in case of alpha_obj==0
 
-#include "ecrad_config.h"
-
 module radiation_cloud_cover
 
   use parkind1, only           : jprb
 
   public
+
+#include "ecrad_config.h"
 
   ! Three overlap schemes.  Note that "Exponential" means that
   ! clear-sky regions have no special significance for computing the

--- a/radiation/radiation_cloud_optics_data.F90
+++ b/radiation/radiation_cloud_optics_data.F90
@@ -13,7 +13,7 @@
 ! Email:   r.j.hogan@ecmwf.int
 !
 
-#include "ecrad_config.h"
+! #include "ecrad_config.h"
 
 module radiation_cloud_optics_data
 
@@ -22,6 +22,7 @@ module radiation_cloud_optics_data
   implicit none
   public
 
+#include "ecrad_config.h"
   !---------------------------------------------------------------------
   ! This type holds the configuration information to compute
   ! cloud optical properties

--- a/radiation/radiation_config.F90
+++ b/radiation/radiation_config.F90
@@ -33,8 +33,6 @@
 ! files in this directory, please inform Robin Hogan.
 !
 
-#include "ecrad_config.h"
-
 module radiation_config
 
   use parkind1,                      only : jprb
@@ -49,6 +47,7 @@ module radiation_config
 
   implicit none
   public
+#include "ecrad_config.h"
 
   ! Configuration codes: use C-style enumerators to avoid having to
   ! remember the numbers
@@ -641,6 +640,8 @@ module radiation_config
      procedure :: set_aerosol_wavelength_mono
      procedure :: consolidate_sw_albedo_intervals
      procedure :: consolidate_lw_emiss_intervals
+     procedure :: get_gas_optics_name_sw
+     procedure :: get_solver_name_sw
 
   end type config_type
 
@@ -2134,5 +2135,17 @@ contains
     write(str, '(a,a,a,a)') message_str, ' "', trim(enum_str(val)), '"'
     write(nulout,'(a,a,a,a,i0,a)') str, ' (', name, '=', val,')'
   end subroutine print_enum
+
+  subroutine get_gas_optics_name_sw(this, out_str)
+    class(config_type),   intent(inout) :: this
+    character(len=*),   intent(out) :: out_str
+    write(out_str,'(a)') trim(GasModelName(this%i_gas_model_sw))
+  end subroutine get_gas_optics_name_sw
+
+  subroutine get_solver_name_sw(this, out_str)
+    class(config_type),   intent(inout) :: this
+    character(len=*),   intent(out) :: out_str
+    write(out_str,'(a)') trim(SolverName(this%i_solver_sw))
+  end subroutine get_solver_name_sw
 
 end module radiation_config

--- a/radiation/radiation_ecckd.F90
+++ b/radiation/radiation_ecckd.F90
@@ -14,8 +14,6 @@
 ! License: see the COPYING file for details
 !
 
-#include "ecrad_config.h"
-
 module radiation_ecckd
 
   use parkind1, only : jprb

--- a/radiation/radiation_ecckd.F90
+++ b/radiation/radiation_ecckd.F90
@@ -476,9 +476,15 @@ contains
     ! Output variables
 
     ! Layer absorption optical depth for each g point
+#if defined NG_SW && defined NG_LW && NG_SW==NG_LW 
+    real(jprb),            intent(out) :: optical_depth_fl(NG_SW,nlev,istartcol:iendcol)
+    ! In the shortwave only, the Rayleigh scattering optical depth
+    real(jprb),  optional, intent(out) :: rayleigh_od_fl(NG_SW,nlev,istartcol:iendcol)
+#else 
     real(jprb),            intent(out) :: optical_depth_fl(this%ng,nlev,istartcol:iendcol)
     ! In the shortwave only, the Rayleigh scattering optical depth
     real(jprb),  optional, intent(out) :: rayleigh_od_fl(this%ng,nlev,istartcol:iendcol)
+#endif
 
     ! Local variables
 

--- a/radiation/radiation_ecckd_gas.F90
+++ b/radiation/radiation_ecckd_gas.F90
@@ -14,8 +14,6 @@
 ! License: see the COPYING file for details
 !
 
-#include "ecrad_config.h"
-
 module radiation_ecckd_gas
 
   use parkind1, only : jprb
@@ -24,6 +22,8 @@ module radiation_ecckd_gas
   implicit none
 
   public
+
+#include "ecrad_config.h"
 
   ! Concentration dependence of individual gases
   enum, bind(c)

--- a/radiation/radiation_flux.F90
+++ b/radiation/radiation_flux.F90
@@ -20,14 +20,13 @@
 !   2021-01-20  R. Hogan  Added heating_rate_out_of_physical_bounds function
 !   2022-12-07  R. Hogan  Added top-of-atmosphere spectral output
 
-#include "ecrad_config.h"
-
 module radiation_flux
 
   use parkind1, only : jprb
 
   implicit none
   public
+#include "ecrad_config.h"
 
   !---------------------------------------------------------------------
   ! This derived type contains the output from the radiation

--- a/radiation/radiation_general_cloud_optics_data.F90
+++ b/radiation/radiation_general_cloud_optics_data.F90
@@ -14,8 +14,6 @@
 ! License: see the COPYING file for details
 !
 
-#include "ecrad_config.h"
-
 module radiation_general_cloud_optics_data
 
   use parkind1, only : jprb
@@ -23,6 +21,8 @@ module radiation_general_cloud_optics_data
   implicit none
 
   public
+
+#include "ecrad_config.h"
 
   !---------------------------------------------------------------------
   ! This type holds the configuration information to compute optical

--- a/radiation/radiation_mcica_lw.F90
+++ b/radiation/radiation_mcica_lw.F90
@@ -18,11 +18,11 @@
 !   2017-07-12  R. Hogan  Call fast adding method if only clouds scatter
 !   2017-10-23  R. Hogan  Renamed single-character variables
 
-#include "ecrad_config.h"
 
 module radiation_mcica_lw
 
   public
+#include "ecrad_config.h"
 
 contains
 

--- a/radiation/radiation_mcica_sw.F90
+++ b/radiation/radiation_mcica_sw.F90
@@ -17,11 +17,11 @@
 !   2017-04-22  R. Hogan  Store surface fluxes at all g-points
 !   2017-10-23  R. Hogan  Renamed single-character variables
 
-#include "ecrad_config.h"
 
 module radiation_mcica_sw
 
   public
+#include "ecrad_config.h"
 
 contains
 

--- a/radiation/radiation_spectral_definition.F90
+++ b/radiation/radiation_spectral_definition.F90
@@ -14,8 +14,6 @@
 ! License: see the COPYING file for details
 !
 
-#include "ecrad_config.h"
-
 module radiation_spectral_definition
 
   use parkind1,    only : jprb
@@ -23,6 +21,8 @@ module radiation_spectral_definition
   implicit none
 
   public
+
+#include "ecrad_config.h"
 
   real(jprb), parameter :: SolarReferenceTemperature       = 5777.0_jprb ! K
   real(jprb), parameter :: TerrestrialReferenceTemperature = 273.15_jprb ! K

--- a/radiation/radiation_two_stream.F90
+++ b/radiation/radiation_two_stream.F90
@@ -21,14 +21,13 @@
 !   2022-11-22  P Ukkonen/R Hogan  Single precision uses no double precision
 !   2023-09-28  R Hogan  Increased security for single-precision SW "k"
 
-#include "ecrad_config.h"
-
 module radiation_two_stream
 
   use parkind1, only : jprb, jprd
 
   implicit none
   public
+#include "ecrad_config.h"
 
   ! Elsasser's factor: the effective factor by which the zenith
   ! optical depth needs to be multiplied to account for longwave

--- a/test/ifs/Makefile
+++ b/test/ifs/Makefile
@@ -127,6 +127,10 @@ test_ecckd_noaer:
 		use_aerosols=false
 	$(DRIVER) config_ecckd_noaer.nam $(INPUT).nc $(INPUT)_ecckd_noaer_out.nc
 
+test_ifsdriver_blocked_ecckd_tc:
+	$(CHANGENAM) $(CONFIG_ECCKD) config_net.nam do_save_net_fluxes=true do_write_double_precision=true nblocksize=8 nrepeat=10
+	$(IFS_DRIVER_BLOCKED) config_net.nam $(INPUT).nc $(INPUT)_ifsdriver_blocked_ecckd_tc_out.nc | tee $(INPUT)_ifsdriver_blocked_ecckd_tc_out.log
+
 # Test the different ways that aerosol optical properties can be
 # averaged, outputing the aerosol properties in each gas-optics
 # spectral interval, producing the following:

--- a/test/ifs/Makefile
+++ b/test/ifs/Makefile
@@ -128,7 +128,7 @@ test_ecckd_noaer:
 	$(DRIVER) config_ecckd_noaer.nam $(INPUT).nc $(INPUT)_ecckd_noaer_out.nc
 
 test_ifsdriver_blocked_ecckd_tc:
-	$(CHANGENAM) $(CONFIG_ECCKD) config_net.nam do_save_net_fluxes=true do_write_double_precision=true nblocksize=8 nrepeat=10
+	$(CHANGENAM) $(CONFIG_ECCKD) config_net.nam do_save_net_fluxes=true do_write_double_precision=true do_save_spectral_flux=false nblocksize=8 nrepeat=10
 	$(IFS_DRIVER_BLOCKED) config_net.nam $(INPUT).nc $(INPUT)_ifsdriver_blocked_ecckd_tc_out.nc | tee $(INPUT)_ifsdriver_blocked_ecckd_tc_out.log
 
 # Test the different ways that aerosol optical properties can be


### PR DESCRIPTION
Currently the official repo is missing two major optimizations found in my ecRad-OTP: compile-time ng and cloudy layer batching. I'm making a pull request for compile-time ng first  - TripleClouds might not get much additional benefit from cloudy layer batching since it already collapses the two cloudy regions in the shortwave, but we'll see.

Here the compile-time NG is implementing in TripleClouds-LW, TripleClouds-SW and ecCKD and the` #ifdef NG_LW.` are added to ecrad_config.h, which helps avoid code bloat. To avoid compilation errors I needed to move the #include "ecrad_config.h" in all files to occur after the module statement.   

Support for General Purpose Timing Library is also added in order to measure the performance impact. I can remove it if you wish but it adds minimal extra code: a few lines in the main Makefile, the driver (I only added it to the blocked IFS driver since this is what should be used for timing tests) and a few instrumentation calls in radiation_interface. 

Compile-time ng has minimal impact on TripleClouds but speeds up ecCKD by a factor of 3 when using the Intel compiler on Atos:

 ``` 
make PROFILE=intel_atos SINGLE_PRECISION=1 GPTL_TIMING=1 
cd test/ifs; make test_ifsdriver_blocked_ecckd_tc 
                                    Called  Recurse     Wall      max      min %_of_radi
  radiation                              1     -       0.114    0.114    0.114   100.00
    radiation_interface:radiation       40     -       0.111 4.76e-03 2.39e-03    97.13
      gas_optics                        40     -       0.030 1.00e-03 7.44e-04    26.61
      cloud_optics                      40     -    4.22e-03 4.44e-04 8.00e-05     3.69
      aerosol_optics                    40     -       0.011 3.75e-04 2.71e-04     9.83
      solver_longwave                   40     -       0.032 1.77e-03 6.86e-04    27.59
      solver_shortwave                  40     -       0.033 1.10e-03 5.17e-04    29.08
 ``` 
 ``` 
make PROFILE=intel_atos SINGLE_PRECISION=1 GPTL_TIMING=1 NG_SW=32 NG_LW=32
cd test/ifs; make test_ifsdriver_blocked_ecckd_tc 
                                    Called  Recurse     Wall      max      min %_of_radi
  radiation                              1     -       0.087    0.087    0.087   100.00
    radiation_interface:radiation       40     -       0.083 2.56e-03 1.79e-03    96.29
      gas_optics                        40     -       0.011 4.27e-04 2.55e-04    12.16
      cloud_optics                      40     -    4.08e-03 3.17e-04 8.10e-05     4.71
      aerosol_optics                    40     -       0.011 3.45e-04 2.71e-04    12.79
      solver_longwave                   40     -       0.028 8.28e-04 6.35e-04    32.40
      solver_shortwave                  40     -       0.029 9.20e-04 4.69e-04    33.85
 ``` 
So a 20-25% speed-up in total.