### PR TITLE
Check `use_aerosols` with `lw_aerosol_scattering`

### DIFF
--- a/radiation/radiation_tripleclouds_lw.F90
+++ b/radiation/radiation_tripleclouds_lw.F90
@@ -232,7 +232,8 @@ contains
       ! Section 3: Clear-sky calculation
       ! --------------------------------------------------------
 
-      if (.not. config%do_lw_aerosol_scattering) then
+      if (.not. config%use_aerosols &
+           .or. .not. config%do_lw_aerosol_scattering) then
         ! No scattering in clear-sky flux calculation; note that here
         ! the first two dimensions of the input arrays are unpacked
         ! into vectors inside the routine        


### PR DESCRIPTION
Check `use_aerosols` in addition to `lw_aerosol_scattering`. In principle, this does not change anything because, if `config%use_aerosols` is false then the single-scattering albedo of aerosols is set to 0 so the results of the two branches, `calc_no_scattering_transmittance_lw` +
`calc_fluxes_no_scattering_lw`, and `calc_ref_trans_lw` + `adding_ica_lw`, is the same. In practice, the results are not exactly equal. This is surprising for the user, who expects that the setting of `config%do_lw_aerosol_scattering` can be disregarded if `config%use_aerosols` is false. Moreover, if `config%use_aerosols` is false, we want to go to the faster calculation,
`calc_no_scattering_transmittance_lw` +
`calc_fluxes_no_scattering_lw`.