### PR TITLE
refactor use_real_rng_state

### DIFF
--- a/radiation/ecrad_config.h
+++ b/radiation/ecrad_config.h
@@ -47,16 +47,6 @@
 #define USE_REAL_RNG_STATE 1
 #endif
 
-! Define RNG_STATE_TYPE based on USE_REAL_RNG_STATE, where jprd
-! refers to a double-precision number regardless of the working
-! precision described by jprb, while jpib describes an 8-byte
-! integer
-#ifdef USE_REAL_RNG_STATE
-#define RNG_STATE_TYPE real(kind=jprd)
-#else
-#define RNG_STATE_TYPE integer(kind=jpib)
-#endif
-
 ! In the IFS, an MPI version of easy_netcdf capability is used so that
 ! only one MPI task reads the data files and shares with the other
 ! tasks. The MPI version is not used for writing files.

--- a/radiation/ecrad_config.h
+++ b/radiation/ecrad_config.h
@@ -47,6 +47,16 @@
 #define USE_REAL_RNG_STATE 1
 #endif
 
+! Define RNG_STATE_TYPE based on USE_REAL_RNG_STATE, where jprd
+! refers to a double-precision number regardless of the working
+! precision described by jprb, while jpib describes an 8-byte
+! integer
+#ifdef USE_REAL_RNG_STATE
+#define RNG_STATE_TYPE real(kind=jprd)
+#else
+#define RNG_STATE_TYPE integer(kind=jpib)
+#endif
+
 ! In the IFS, an MPI version of easy_netcdf capability is used so that
 ! only one MPI task reads the data files and shares with the other
 ! tasks. The MPI version is not used for writing files.

--- a/radiation/ecrad_config.h
+++ b/radiation/ecrad_config.h
@@ -32,6 +32,21 @@
 #define DWD_VECTOR_OPTIMIZATIONS 1
 #endif
 
+
+! A requirement of the generator is that the operation mod(A*X,M) is
+! performed with no loss of precision, so type used for A and X must
+! be able to hold the largest possible value of A*X without
+! overflowing, going negative or losing precision. The largest
+! possible value is 48271*2147483647 = 103661183124337. This number
+! can be held in either a double-precision real number, or an 8-byte
+! integer. Either may be used, but on some hardwares it has been
+! found that operations on double-precision reals are faster. Select
+! which you prefer by defining USE_REAL_RNG_STATE for double
+! precision, or undefining it for an 8-byte integer.
+#if defined (__SX__)
+#define USE_REAL_RNG_STATE 1
+#endif
+
 ! In the IFS, an MPI version of easy_netcdf capability is used so that
 ! only one MPI task reads the data files and shares with the other
 ! tasks. The MPI version is not used for writing files.

--- a/radiation/radiation_random_numbers.F90
+++ b/radiation/radiation_random_numbers.F90
@@ -58,6 +58,16 @@ module radiation_random_numbers
   ! - this can be increased
   integer(kind=jpim), parameter :: NMaxStreams = 512
 
+  ! Define RNG_STATE_TYPE based on USE_REAL_RNG_STATE, where jprd
+  ! refers to a double-precision number regardless of the working
+  ! precision described by jprb, while jpib describes an 8-byte
+  ! integer
+#ifdef USE_REAL_RNG_STATE
+#define RNG_STATE_TYPE real(kind=jprd)
+#else
+#define RNG_STATE_TYPE integer(kind=jpib)
+#endif
+
   ! The constants used in the main random number generator
   RNG_STATE_TYPE , parameter :: IMinstdA  = 48271
   RNG_STATE_TYPE , parameter :: IMinstdM  = 2147483647

--- a/radiation/radiation_random_numbers.F90
+++ b/radiation/radiation_random_numbers.F90
@@ -39,6 +39,8 @@
 ! Modifications
 !   2022-12-01  R. Hogan  Fixed zeroed state in single precision
 
+#include "ecrad_config.h"
+
 module radiation_random_numbers
 
   use parkind1, only : jprb, jprd, jpim, jpib
@@ -55,18 +57,6 @@ module radiation_random_numbers
   ! Maximum number of random numbers that can be computed in one call
   ! - this can be increased
   integer(kind=jpim), parameter :: NMaxStreams = 512
-  
-  ! A requirement of the generator is that the operation mod(A*X,M) is
-  ! performed with no loss of precision, so type used for A and X must
-  ! be able to hold the largest possible value of A*X without
-  ! overflowing, going negative or losing precision. The largest
-  ! possible value is 48271*2147483647 = 103661183124337. This number
-  ! can be held in either a double-precision real number, or an 8-byte
-  ! integer. Either may be used, but on some hardwares it has been
-  ! found that operations on double-precision reals are faster. Select
-  ! which you prefer by defining USE_REAL_RNG_STATE for double
-  ! precision, or undefining it for an 8-byte integer.
-#define USE_REAL_RNG_STATE 1
 
   ! Define RNG_STATE_TYPE based on USE_REAL_RNG_STATE, where jprd
   ! refers to a double-precision number regardless of the working

--- a/radiation/radiation_random_numbers.F90
+++ b/radiation/radiation_random_numbers.F90
@@ -58,16 +58,6 @@ module radiation_random_numbers
   ! - this can be increased
   integer(kind=jpim), parameter :: NMaxStreams = 512
 
-  ! Define RNG_STATE_TYPE based on USE_REAL_RNG_STATE, where jprd
-  ! refers to a double-precision number regardless of the working
-  ! precision described by jprb, while jpib describes an 8-byte
-  ! integer
-#ifdef USE_REAL_RNG_STATE
-#define RNG_STATE_TYPE real(kind=jprd)
-#else
-#define RNG_STATE_TYPE integer(kind=jpib)
-#endif
-
   ! The constants used in the main random number generator
   RNG_STATE_TYPE , parameter :: IMinstdA  = 48271
   RNG_STATE_TYPE , parameter :: IMinstdM  = 2147483647


### PR DESCRIPTION
Refactor use_real_rng_state such that it is only used when compiling with __SX__.
I am still not sure which platform is requiring this and would assume that one most platforms integers are faster than floats.