### PR TITLE
Remove allocation of inv_cloud_effective_size

### DIFF
--- a/radiation/radiation_cloud.F90
+++ b/radiation/radiation_cloud.F90
@@ -140,7 +140,6 @@ contains
     allocate(this%fraction(ncol,nlev))
     allocate(this%overlap_param(ncol,nlev-1))
     allocate(this%fractional_std(ncol,nlev))
-    allocate(this%inv_cloud_effective_size(ncol,nlev))
 
     if (present(use_inhom_effective_size)) then
       if (use_inhom_effective_size) then


### PR DESCRIPTION
Remove allocation of inv_cloud_effective_size since this field is only needed for special settings. In our ICON configuration, it fails the cloud check (when activated) although it is not needed.