### PR TITLE
 Use correct input file for general aerosol optics in IFS-style drivers #30 

### DIFF
--- a/ifs/radiation_setup.F90
+++ b/ifs/radiation_setup.F90
@@ -292,7 +292,11 @@ CONTAINS
 
       ! The default aerosol optics file is the following - please
       ! update here, not in radiation/module/radiation_config.F90
-      RAD_CONFIG%AEROSOL_OPTICS_OVERRIDE_FILE_NAME = 'aerosol_ifs_rrtm_46R1_with_NI_AM.nc'
+      IF (RAD_CONFIG%USE_GENERAL_AEROSOL_OPTICS) THEN
+        RAD_CONFIG%AEROSOL_OPTICS_OVERRIDE_FILE_NAME = 'aerosol_ifs_49R1_20230119.nc'
+      ELSE
+        RAD_CONFIG%AEROSOL_OPTICS_OVERRIDE_FILE_NAME = 'aerosol_ifs_rrtm_46R1_with_NI_AM.nc'
+      END IF
 
     ELSE
       ! Using Tegen climatology
@@ -439,7 +443,7 @@ CONTAINS
     ! second emissivity to represent values within it.
     CALL YDERAD%YSPECTPLANCK%INIT(2, [ 8.0E-6_JPRB, 13.0E-6_JPRB ], &
          &  [ 1,2,1 ])
-      
+
     ! Populate the mapping between the 14 RRTM shortwave bands and the
     ! 6 albedo inputs.
     YDERAD%NSW = 6
@@ -518,25 +522,34 @@ CONTAINS
          &  PRADIATION%NWEIGHT_PAR, PRADIATION%IBAND_PAR, PRADIATION%WEIGHT_PAR,&
          &  'photosynthetically active radiation, PAR')
 
-    IF (YDERAD%NAERMACC > 0) THEN
-      ! With the MACC aerosol climatology we need to add in the
-      ! background aerosol afterwards using the Tegen arrays.  In this
-      ! case we first configure the background aerosol mass-extinction
-      ! coefficient at 550 nm, which corresponds to the 10th RRTMG
-      ! shortwave band.
-      PRADIATION%TROP_BG_AER_MASS_EXT  = DRY_AEROSOL_MASS_EXTINCTION(RAD_CONFIG,&
-           &                                   ITYPE_TROP_BG_AER, 550.0E-9_JPRB)
-      PRADIATION%STRAT_BG_AER_MASS_EXT = DRY_AEROSOL_MASS_EXTINCTION(RAD_CONFIG,&
-           &                                   ITYPE_STRAT_BG_AER, 550.0E-9_JPRB)
+    ! PRADIATION%TROP_BG_AER_MASS_EXT  = 0.0_JPRB
+    ! PRADIATION%STRAT_BG_AER_MASS_EXT = 0.0_JPRB
+    ! IF (YDERAD%NAERMACC > 0) THEN
+    !   ! With the MACC aerosol climatology we need to add in the
+    !   ! background aerosol afterwards using the Tegen arrays.  In this
+    !   ! case we first configure the background aerosol mass-extinction
+    !   ! coefficient at 550 nm, which corresponds to the 10th RRTMG
+    !   ! shortwave band.
+    !   IF (ITYPE_TROP_BG_AER > 0) THEN
+    !     PRADIATION%TROP_BG_AER_MASS_EXT  = DRY_AEROSOL_MASS_EXTINCTION(RAD_CONFIG,&
+    !         &                                   ITYPE_TROP_BG_AER, 550.0e-9_JPRB)
+    !     WRITE(NULOUT,'(a,i2,a,e12.4,a)') 'Tropospheric background:  aerosol type ',&
+    !         &  ITYPE_TROP_BG_AER, ', 550-nm mass-extinction coefficient ', &
+    !         &  PRADIATION%TROP_BG_AER_MASS_EXT, ' m2 kg-1'
+    !   ELSE
+    !     WRITE(NULOUT,'(a)') 'No tropospheric background aerosol'
+    !   ENDIF
 
-      WRITE(NULOUT,'(a,i0)') 'Tropospheric background uses aerosol type ',&
-           &                 ITYPE_TROP_BG_AER
-      WRITE(NULOUT,'(a,i0)') 'Stratospheric background uses aerosol type ',&
-           &                 ITYPE_STRAT_BG_AER
-    ELSE
-      PRADIATION%TROP_BG_AER_MASS_EXT  = 0.0_JPRB
-      PRADIATION%STRAT_BG_AER_MASS_EXT = 0.0_JPRB
-    ENDIF
+    !   IF (ITYPE_STRAT_BG_AER > 0) THEN
+    !     PRADIATION%STRAT_BG_AER_MASS_EXT = DRY_AEROSOL_MASS_EXTINCTION(RAD_CONFIG,&
+    !         &                                   ITYPE_STRAT_BG_AER, 550.0e-9_JPRB)
+    !     WRITE(NULOUT,'(a,i2,a,e12.4,a)') 'Stratospheric background: aerosol type ',&
+    !         &  ITYPE_STRAT_BG_AER, ', 550-nm mass-extinction coefficient ', &
+    !         &  PRADIATION%STRAT_BG_AER_MASS_EXT, ' m2 kg-1'
+    !   ELSE
+    !     WRITE(NULOUT,'(a)') 'No stratospheric background aerosol'
+    !   ENDIF
+    ! ENDIF
 
     IF (IVERBOSESETUP > 1) THEN
       WRITE(NULOUT,'(a)') '-------------------------------------------------------------------------------'

--- a/radiation/radiation_thermodynamics.F90
+++ b/radiation/radiation_thermodynamics.F90
@@ -76,10 +76,10 @@ contains
     if (present(use_h2o_sat)) then
       use_h2o_sat_local = use_h2o_sat
     end if
-    
+
     if (use_h2o_sat_local) then
       allocate(this%h2o_sat_liq(ncol,nlev))
-    end if    
+    end if
 
     if (lhook) call dr_hook('radiation_thermodynamics:allocate',1,hook_handle)
 
@@ -109,7 +109,7 @@ contains
     end if
 
     if (lhook) call dr_hook('radiation_thermodynamics:deallocate',1,hook_handle)
-  
+
   end subroutine deallocate_thermodynamics_arrays
 
 
@@ -168,7 +168,7 @@ contains
 
     class(thermodynamics_type), intent(in)  :: this
     integer,                    intent(in)  :: istartcol, iendcol
-    real(jprb),                 intent(out) :: layer_mass(:,:)
+    real(jprb),                 intent(out) :: layer_mass(istartcol:iendcol,ubound(this%pressure_hl,2))
 
     integer    :: nlev
     real(jprb) :: inv_g
@@ -183,8 +183,8 @@ contains
     layer_mass(istartcol:iendcol,1:nlev) &
          &  = ( this%pressure_hl(istartcol:iendcol,2:nlev+1) &
          &     -this%pressure_hl(istartcol:iendcol,1:nlev  )  ) &
-         &  * inv_g 
-    
+         &  * inv_g
+
     if (lhook) call dr_hook('radiation_thermodynamics:get_layer_mass',1,hook_handle)
 
   end subroutine get_layer_mass
@@ -214,7 +214,7 @@ contains
     layer_mass = ( this%pressure_hl(icol,2:nlev+1) &
              &    -this%pressure_hl(icol,1:nlev  )  ) &
              &   * inv_g
-    
+
     if (lhook) call dr_hook('radiation_thermodynamics:get_layer_mass_column',1,hook_handle)
 
   end subroutine get_layer_mass_column
@@ -260,7 +260,7 @@ contains
       ! don't take the logarithm of the first pressure in each column.
       layer_separation(i1:i2,1) = R_over_g * temperature_hl(i1:i2,2) &
            &                    * log(pressure_hl(i1:i2,3)/pressure_hl(i1:i2,2))
-      
+
       ! For other layers we take the separation between midpoints to
       ! be half the separation between the half-levels at the edge of
       ! the two adjacent layers
@@ -285,7 +285,7 @@ contains
 
     end if
 
-    if (lhook) call dr_hook('radiation_thermodynamics:get_layer_separation',1,hook_handle)    
+    if (lhook) call dr_hook('radiation_thermodynamics:get_layer_separation',1,hook_handle)
 
   end subroutine get_layer_separation
 
@@ -326,5 +326,5 @@ contains
     if (lhook) call dr_hook('radiation_thermodynamics:out_of_physical_bounds',1,hook_handle)
 
   end function out_of_physical_bounds
-  
+
 end module radiation_thermodynamics


### PR DESCRIPTION
NB: This is the first of two PRs that separates the changes in #30 into separate PRs

This is a patch to the 1.6.1-beta branch. I will file a similar one against master in the future.

I noticed that results differed with the 49r1 namelist file between the IFS-style drivers and the "default" ecrad driver, while being the same with the 47r3 namelist file.
I managed to trace this to a different aerosol data file being used, when general_aerosol_optics is active.

This PR contributes:

* a fix to radiation_setup that chooses a different aerosol data file when general_aerosol_optics is active
* a fix to radiation_setup that disables the call to DRY_AEROSOL_MASS_EXTINCTION, which fails with a segfault. Since the aerosol setup is already performed during the input reading, it is redundant in the standalone context anyway.