### PR TITLE
Add default flags to CMake build types

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -33,10 +33,6 @@ endif()
 # ... before doing a final find_package to make it available.
 find_package( ecbuild ${MINIMUM_ECBUILD_VERSION} REQUIRED )
 
-# We set the <PNAME>_ECBUILD_COMPILE_FLAGS variable to an empty file. This ensures that we can
-# specify a default set of compilation flags as well as per-file overwrites as part of the CMake config.
-set( ECRAD_ECBUILD_COMPILE_FLAGS ${CMAKE_CURRENT_SOURCE_DIR}/cmake/ecrad_init_flags.cmake CACHE FILEPATH "")
-
 project( ecrad LANGUAGES Fortran )
 ecbuild_enable_fortran( REQUIRED )
 set( CMAKE_EXPORT_COMPILE_COMMANDS ON )

--- a/cmake/ecrad_compile_flags.cmake
+++ b/cmake/ecrad_compile_flags.cmake
@@ -6,11 +6,6 @@
 # granted to it by virtue of its status as an intergovernmental organisation
 # nor does it submit to any jurisdiction.
 
-# Capture ecbuild defaults and/or flags set by a toolchain
-set( ${PNAME}_Fortran_FLAGS "${${PNAME}_Fortran_FLAGS} ${ECBUILD_Fortran_FLAGS}" )
-set( ${PNAME}_Fortran_FLAGS_BIT "${${PNAME}_Fortran_FLAGS_BIT} ${ECBUILD_Fortran_FLAGS_BIT}" )
-set( ${PNAME}_Fortran_FLAGS_DEBUG "${${PNAME}_Fortran_FLAGS_DEBUG} ${ECBUILD_Fortran_FLAGS_DEBUG}" )
-
 if(CMAKE_Fortran_COMPILER_ID MATCHES "Cray")
   set(checkbounds_flags   "-Rb")
   set(fpe_flags           "-Ktrap=fp")
@@ -42,12 +37,11 @@ elseif(CMAKE_Fortran_COMPILER_ID MATCHES "Intel")
 elseif(CMAKE_Fortran_COMPILER_ID MATCHES "PGI|NVHPC")
   set(fpe_flags           "-Ktrap=fp")
   set(vectorization_flags "-O3 -fast")
-  string(REPLACE "-O2" "" ${PNAME}_Fortran_FLAGS_BIT ${${PNAME}_Fortran_FLAGS_BIT})
+  string(REPLACE "-O2" "" CMAKE_Fortran_FLAGS_BIT ${CMAKE_Fortran_FLAGS_BIT})
   set(checkbounds_flags   "-Mbounds")
 
 endif()
 
-ecbuild_add_fortran_flags( "-g -O0"   NAME base_debug BUILD DEBUG )
 if( DEFINED align_flags )
   ecbuild_add_fortran_flags( "${align_flags}"   NAME align )
 endif()
@@ -58,8 +52,7 @@ if( DEFINED convert_flags )
   ecbuild_add_fortran_flags( "${convert_flags}"   NAME convert )
 endif()
 if( DEFINED vectorization_flags )
-  # vectorization flags must be per-sourcefile overrideable, so are set via ${PNAME}_Fortran_FLAGS
-  set( ${PNAME}_Fortran_FLAGS_BIT "${${PNAME}_Fortran_FLAGS_BIT} ${vectorization_flags}" )
+  ecbuild_add_fortran_flags( "${vectorization_flags}" NAME vectorization BUILD BIT )
 endif()
 if( DEFINED fpmodel_flags )
   ecbuild_add_fortran_flags( "${fpmodel_flags}"   NAME fpmodel BUILD BIT )
@@ -68,14 +61,12 @@ if( DEFINED inline_flags )
   ecbuild_add_fortran_flags( "${inline_flags}"   NAME inline BUILD BIT )
 endif()
 
-if( CMAKE_BUILD_TYPE MATCHES "Debug" )
-  foreach( debug_flag    fpe initsnan checkbounds )
-    if( ${debug_flag}_flags )
-      set( ${PNAME}_Fortran_FLAGS_DEBUG "${${PNAME}_Fortran_FLAGS_DEBUG} ${${debug_flag}_flags}" )
-    endif()
-  endforeach()
-  if(CMAKE_Fortran_COMPILER_ID MATCHES "Intel")
-    # In case '-check all' has been added, we need to remove the '-check arg_temp_created' warnings
-    set( ${PNAME}_Fortran_FLAGS_DEBUG "${${PNAME}_Fortran_FLAGS_DEBUG} -check noarg_temp_created" )
+foreach( debug_flag fpe initsnan checkbounds )
+  if( ${debug_flag}_flags )
+    ecbuild_add_fortran_flags( "${${debug_flag}_flags}" NAME ${debug_flag} BUILD DEBUG )
   endif()
+endforeach()
+if(CMAKE_Fortran_COMPILER_ID MATCHES "Intel")
+  # In case '-check all' has been added, we need to remove the '-check arg_temp_created' warnings
+  ecbuild_add_fortran_flags( "-check noarg_temp_created" NAME noarg BUILD DEBUG)
 endif()

--- a/cmake/ecrad_init_flags.cmake
+++ b/cmake/ecrad_init_flags.cmake
@@ -1,9 +1,0 @@
-# (C) Copyright 2014- ECMWF.
-#
-# This software is licensed under the terms of the Apache Licence Version 2.0
-# which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
-# In applying this licence, ECMWF does not waive the privileges and immunities
-# granted to it by virtue of its status as an intergovernmental organisation
-# nor does it submit to any jurisdiction.
-
-# Empty file to trigger ecbuild to use ${PNAME}_<LANG>_FLAGS

--- a/driver/CMakeLists.txt
+++ b/driver/CMakeLists.txt
@@ -57,17 +57,17 @@ if( CMAKE_BUILD_TYPE MATCHES "Debug" )
     if(CMAKE_Fortran_COMPILER_ID MATCHES "GNU")
         set_source_files_properties(
             "ecrad_ifs_driver_blocked.F90"
-            PROPERTIES COMPILE_FLAGS "-fcheck=no-bounds"
+            PROPERTIES COMPILE_OPTIONS "-fcheck=no-bounds"
         )
     elseif(CMAKE_Fortran_COMPILER_ID MATCHES "Intel")
         set_source_files_properties(
             "ecrad_ifs_driver_blocked.F90"
-            PROPERTIES COMPILE_FLAGS "-check nobounds"
+            PROPERTIES COMPILE_OPTIONS "-check nobounds"
         )
     elseif(CMAKE_Fortran_COMPILER_ID MATCHES "PGI|NVHPC")
         set_source_files_properties(
             "ecrad_ifs_driver_blocked.F90"
-            PROPERTIES COMPILE_FLAGS "-Mnobounds"
+            PROPERTIES COMPILE_OPTIONS "-Mnobounds"
         )
     endif()
 endif()


### PR DESCRIPTION
One option to address #46.

Replaces the "custom compilation flags" approach that is currently used in ecRad's build system. This approach requires the project to set `ECRAD_ECBUILD_COMPILE_FLAGS`, but setting this variable has the effect that "default compilation flags are not loaded" (see [ecBuild docs](https://ecbuild.readthedocs.io/en/latest/macros/ecbuild_compiler_flags.html#using-custom-compilation-flags)). Due to this, none of the build types contain any optimization flags, and these lines
```cmake
set( ${PNAME}_Fortran_FLAGS "${${PNAME}_Fortran_FLAGS} ${ECBUILD_Fortran_FLAGS}" )
set( ${PNAME}_Fortran_FLAGS_BIT "${${PNAME}_Fortran_FLAGS_BIT} ${ECBUILD_Fortran_FLAGS_BIT}" )
set( ${PNAME}_Fortran_FLAGS_DEBUG "${${PNAME}_Fortran_FLAGS_DEBUG} ${ECBUILD_Fortran_FLAGS_DEBUG}" )
```
don't do anything either, as the `ECBUILD_*_FLAGS*` values are not defined/empty.

The benefit of the previously used approach with the custom flags is that one could override flags on a per-file basis, but this feature has not been used anywhere as far as I can tell (it would require the usage of the `OVERRIDE_COMPILE_FLAGS` property, which I did not find anywhere in ecRad).

_Adding_ additional compile flags to source files is still possible via normal CMake mechanisms with the `COMPILE_OPTIONS`/`COMPILE_FLAGS` property.

To fix the problem raised in #46, there are (at least) two options. The first one is presented in this PR. The second one would be to properly define default flags, which would most likely amount to copy-pasting some ecBuild default values. Since the override feature for the custom flags was not used, I went with the first option. If however you intend to use the override feature in the near future, I would gladly close this PR and open a new one with the second option and properly defined default flags.

Let me know what you think!