### PR TITLE
omp: change omp declare simd guarding

### DIFF
--- a/radiation/radiation_cloud_generator.F90
+++ b/radiation/radiation_cloud_generator.F90
@@ -539,8 +539,7 @@ contains
     use parkind1,              only : jprb
     use radiation_pdf_sampler, only : pdf_sampler_type
     implicit none
-#if defined(__GFORTRAN__) || defined(__PGI) || defined(__NEC__) || defined(__INTEL_LLVM_COMPILER)
-#else
+#if defined(__COMPILER_THAT_SUPPORTS_THIS_DIRECTIVE)
     !$omp declare simd(sample_from_pdf_simd) uniform(this) &
     !$omp linear(ref(fsd)) linear(ref(cdf))
 #endif


### PR DESCRIPTION
Hello, 

The original code shows that the directive is disabled for GCC, PGI, NEC, Intel LLVM compilers, and I conclude it is not expected to compiler with these compilers. I also encountered compilation failures with other LLVM based compilers.

Wouldn't it be more productive to use a compiler whitelist instead of blacklisting all compilers except one ?

If the said compiler(s) do not export any macro, this could be controlled from the build system.

Best,
Antoine.