### PR TITLE
Add `PARAMETER` attribute to `RPLRG`

### DIFF
--- a/ifsaux/yomdyncore.F90
+++ b/ifsaux/yomdyncore.F90
@@ -20,7 +20,7 @@ SAVE
 ! Aqua planet?
 LOGICAL, PARAMETER :: LAQUA = .false.
 ! Small-planet factor
-REAL(KIND=JPRB)    :: RPLRG = 1.0
+REAL(KIND=JPRB), PARAMETER :: RPLRG = 1.0_JPRB
 
 
 END MODULE YOMDYNCORE


### PR DESCRIPTION
A small PR to fix the strangest of bugs in IFS coupled nvhpc 24.5 sp builds.