### PR TITLE
Force static linking for GPU library without side-effects

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -84,12 +84,6 @@ ecbuild_add_option(
     REQUIRED_PACKAGES "OpenACC COMPONENTS Fortran"
     CONDITION CMAKE_Fortran_COMPILER_ID MATCHES "PGI|NVHPC"
 )
-if( HAVE_ACC )
-    if( DEFINED BUILD_SHARED_LIBS AND BUILD_SHARED_LIBS )
-        ecbuild_warn( "OpenACC enabled: Switching to static linking" )
-    endif()
-    set( BUILD_SHARED_LIBS OFF CACHE BOOL "Build using shared libraries" FORCE )
-endif()
 
 if( CMAKE_VERSION VERSION_LESS 3.25 )
     set( NVTX_TARGET CUDA::nvToolsExt )

--- a/radiation/CMakeLists.txt
+++ b/radiation/CMakeLists.txt
@@ -70,9 +70,22 @@ set( radiation_SOURCES
         radiation_two_stream.F90
 )
 
+if( BUILD_SHARED_LIBS )
+    if( HAVE_ACC )
+        ecbuild_warn( "OpenACC enabled: Forcing static linking for ecrad.${PREC}" )
+        set( LIBRARY_TYPE STATIC )
+    else()
+        set( LIBRARY_TYPE SHARED )
+    endif()
+else()
+    set( LIBRARY_TYPE STATIC )
+endif()
+
 ecbuild_add_library(
     TARGET
         ecrad.${PREC}
+    TYPE
+        ${LIBRARY_TYPE}
     SOURCES
         ${radiation_SOURCES}
     PUBLIC_INCLUDES


### PR DESCRIPTION
This changes the way how static linking is enforced for a GPU build to avoid side effects on other ecbundle projects.