### PR TITLE
Fix non-automatic allocation on assignment with matmul on Intel

### DIFF
--- a/radiation/radiation_general_cloud_optics_data.F90
+++ b/radiation/radiation_general_cloud_optics_data.F90
@@ -186,6 +186,9 @@ contains
     call delta_eddington(mass_ext, ssa, asymmetry)
 
     ! Thin averaging
+    if (.not. allocated(this%mass_ext)) then
+      allocate(this%mass_ext(size(mapping,1), size(mass_ext,2)))
+    end if
     this%mass_ext  = matmul(mapping, mass_ext)
     this%ssa       = matmul(mapping, mass_ext*ssa) / this%mass_ext
     this%asymmetry = matmul(mapping, mass_ext*ssa*asymmetry) / (this%mass_ext*this%ssa)


### PR DESCRIPTION
With ifort 2019.5.281 or intel/oneapi/2021.4 (used in Meteo-France's HPC),
a "segmentation fault address not mapped to object" to  this%ssa at the init step during execution in radiation_general_cloud_optics_data.f90 in the case of general cloud optics :

`this%ssa       = matmul(mapping, mass_ext*ssa) / this%mass_ext`
because 
`this%mass_ext  = matmul(mapping, mass_ext)`

leads to unallocated this%mass_ext

No problem with gfortran 13.3. The reason (found By Robin H.) is that Fortran 2003 standard states that an array should be automatically allocated on assignment, but that Intel does not automatically do this:
https://stackoverflow.com/questions/22313883/allocatable-array-valued-function-gfortran-vs-ifort

forcing the allocation is a solution when using ifort.