### PR TITLE
Fix use of unallocated arrays in IFS drivers

### DIFF
--- a/driver/ecrad_ifs_driver.F90
+++ b/driver/ecrad_ifs_driver.F90
@@ -450,21 +450,28 @@ program ecrad_ifs_driver
   ! "up" fluxes are actually net fluxes at this point - we modify the
   ! upwelling flux so that net=dn-up, while the TOA and surface
   ! downwelling fluxes are correct.
-  flux%sw_up = -flux%sw_up
-  flux%sw_up(:,1) = flux%sw_up(:,1)+flux%sw_dn(:,1)
-  flux%sw_up(:,nlev+1) = flux%sw_up(:,nlev+1)+flux%sw_dn(:,nlev+1)
+  if(yradiation%rad_config%do_sw) then
+    flux%sw_up = -flux%sw_up
+    flux%sw_up(:,1) = flux%sw_up(:,1)+flux%sw_dn(:,1)
+    flux%sw_up(:,nlev+1) = flux%sw_up(:,nlev+1)+flux%sw_dn(:,nlev+1)
+    if(yradiation%rad_config%do_clear) then
+      flux%sw_up_clear = -flux%sw_up_clear
+      flux%sw_up_clear(:,1) = flux%sw_up_clear(:,1)+flux%sw_dn_clear(:,1)
+      flux%sw_up_clear(:,nlev+1) = flux%sw_up_clear(:,nlev+1)+flux%sw_dn_clear(:,nlev+1)
+    endif
 
-  flux%lw_up = -flux%lw_up
-  flux%lw_up(:,1) = flux%lw_up(:,1)+flux%lw_dn(:,1)
-  flux%lw_up(:,nlev+1) = flux%lw_up(:,nlev+1)+flux%lw_dn(:,nlev+1)
+  endif
 
-  flux%sw_up_clear = -flux%sw_up_clear
-  flux%sw_up_clear(:,1) = flux%sw_up_clear(:,1)+flux%sw_dn_clear(:,1)
-  flux%sw_up_clear(:,nlev+1) = flux%sw_up_clear(:,nlev+1)+flux%sw_dn_clear(:,nlev+1)
-
-  flux%lw_up_clear = -flux%lw_up_clear
-  flux%lw_up_clear(:,1) = flux%lw_up_clear(:,1)+flux%lw_dn_clear(:,1)
-  flux%lw_up_clear(:,nlev+1) = flux%lw_up_clear(:,nlev+1)+flux%lw_dn_clear(:,nlev+1)
+  if(yradiation%rad_config%do_lw) then
+    flux%lw_up = -flux%lw_up
+    flux%lw_up(:,1) = flux%lw_up(:,1)+flux%lw_dn(:,1)
+    flux%lw_up(:,nlev+1) = flux%lw_up(:,nlev+1)+flux%lw_dn(:,nlev+1)
+    if(yradiation%rad_config%do_clear) then
+      flux%lw_up_clear = -flux%lw_up_clear
+      flux%lw_up_clear(:,1) = flux%lw_up_clear(:,1)+flux%lw_dn_clear(:,1)
+      flux%lw_up_clear(:,nlev+1) = flux%lw_up_clear(:,nlev+1)+flux%lw_dn_clear(:,nlev+1)
+    endif
+  endif
 
 #ifndef NO_OPENMP
   tstop = omp_get_wtime()

--- a/driver/ecrad_ifs_driver.F90
+++ b/driver/ecrad_ifs_driver.F90
@@ -406,7 +406,7 @@ program ecrad_ifs_driver
         ! Call the ECRAD radiation scheme; note that we are simply
         ! passing arrays in rather than ecRad structures, which are
         ! used here just for convenience
-        call radiation_scheme(yradiation, istartcol, iendcol, ncol, nlev, size(aerosol%mixing_ratio,3), &
+        call radiation_scheme(yradiation, istartcol, iendcol, ncol, nlev, yradiation%rad_config%n_aerosol_types, &
              &  single_level%solar_irradiance, single_level%cos_sza, single_level%skin_temperature, &
              &  single_level%sw_albedo, single_level%sw_albedo_direct, single_level%lw_emissivity, &
              &  ccn_land, ccn_sea, longitude_rad, sin_latitude, land_frac, pressure_fl, temperature_fl, &

--- a/driver/ecrad_ifs_driver.F90
+++ b/driver/ecrad_ifs_driver.F90
@@ -315,21 +315,21 @@ program ecrad_ifs_driver
   call flux%allocate(yradiation%rad_config, 1, ncol, nlev)
 
   ! set relevant fluxes to zero
-  flux%lw_up(:,:) = 0._jprb
-  flux%lw_dn(:,:) = 0._jprb
-  flux%sw_up(:,:) = 0._jprb
-  flux%sw_dn(:,:) = 0._jprb
-  flux%sw_dn_direct(:,:) = 0._jprb
-  flux%lw_up_clear(:,:) = 0._jprb
-  flux%lw_dn_clear(:,:) = 0._jprb
-  flux%sw_up_clear(:,:) = 0._jprb
-  flux%sw_dn_clear(:,:) = 0._jprb
-  flux%sw_dn_direct_clear(:,:) = 0._jprb
+  if(allocated(flux%lw_up)) flux%lw_up(:,:) = 0._jprb
+  if(allocated(flux%lw_dn)) flux%lw_dn(:,:) = 0._jprb
+  if(allocated(flux%sw_up)) flux%sw_up(:,:) = 0._jprb
+  if(allocated(flux%sw_dn)) flux%sw_dn(:,:) = 0._jprb
+  if(allocated(flux%sw_dn_direct)) flux%sw_dn_direct(:,:) = 0._jprb
+  if(allocated(flux%lw_up_clear)) flux%lw_up_clear(:,:) = 0._jprb
+  if(allocated(flux%lw_dn_clear)) flux%lw_dn_clear(:,:) = 0._jprb
+  if(allocated(flux%sw_up_clear)) flux%sw_up_clear(:,:) = 0._jprb
+  if(allocated(flux%sw_dn_clear)) flux%sw_dn_clear(:,:) = 0._jprb
+  if(allocated(flux%sw_dn_direct_clear)) flux%sw_dn_direct_clear(:,:) = 0._jprb
 
-  flux%lw_dn_surf_canopy(:,:) = 0._jprb
-  flux%sw_dn_diffuse_surf_canopy(:,:) = 0._jprb
-  flux%sw_dn_direct_surf_canopy(:,:) = 0._jprb
-  flux%lw_derivatives(:,:) = 0._jprb
+  if(allocated(flux%lw_dn_surf_canopy)) flux%lw_dn_surf_canopy(:,:) = 0._jprb
+  if(allocated(flux%sw_dn_diffuse_surf_canopy)) flux%sw_dn_diffuse_surf_canopy(:,:) = 0._jprb
+  if(allocated(flux%sw_dn_direct_surf_canopy)) flux%sw_dn_direct_surf_canopy(:,:) = 0._jprb
+  if(allocated(flux%lw_derivatives)) flux%lw_derivatives(:,:) = 0._jprb
 
   ! Allocate memory for additional arrays
   allocate(ccn_land(ncol))

--- a/driver/ecrad_ifs_driver_blocked.F90
+++ b/driver/ecrad_ifs_driver_blocked.F90
@@ -412,7 +412,7 @@ program ecrad_ifs_driver
         call radiation_scheme &
              & (yradiation, &
              &  1, il, nproma, &                       ! startcol, endcol, ncol
-             &  nlev, size(aerosol%mixing_ratio,3), &    ! nlev, naerosols
+             &  nlev, yradiation%rad_config%n_aerosol_types, &    ! nlev, naerosols
              &  single_level%solar_irradiance, &                               ! solar_irrad
              ! array inputs
              &  zrgp(1,ifs_config%iamu0,ib), zrgp(1,ifs_config%its,ib), &    ! mu0, skintemp

--- a/driver/ecrad_ifs_driver_blocked.F90
+++ b/driver/ecrad_ifs_driver_blocked.F90
@@ -324,21 +324,21 @@ program ecrad_ifs_driver
   call flux%allocate(yradiation%rad_config, 1, ncol, nlev)
 
   ! set relevant fluxes to zero
-  flux%lw_up(:,:) = 0._jprb
-  flux%lw_dn(:,:) = 0._jprb
-  flux%sw_up(:,:) = 0._jprb
-  flux%sw_dn(:,:) = 0._jprb
-  flux%sw_dn_direct(:,:) = 0._jprb
-  flux%lw_up_clear(:,:) = 0._jprb
-  flux%lw_dn_clear(:,:) = 0._jprb
-  flux%sw_up_clear(:,:) = 0._jprb
-  flux%sw_dn_clear(:,:) = 0._jprb
-  flux%sw_dn_direct_clear(:,:) = 0._jprb
+  if(allocated(flux%lw_up)) flux%lw_up(:,:) = 0._jprb
+  if(allocated(flux%lw_dn)) flux%lw_dn(:,:) = 0._jprb
+  if(allocated(flux%sw_up)) flux%sw_up(:,:) = 0._jprb
+  if(allocated(flux%sw_dn)) flux%sw_dn(:,:) = 0._jprb
+  if(allocated(flux%sw_dn_direct)) flux%sw_dn_direct(:,:) = 0._jprb
+  if(allocated(flux%lw_up_clear)) flux%lw_up_clear(:,:) = 0._jprb
+  if(allocated(flux%lw_dn_clear)) flux%lw_dn_clear(:,:) = 0._jprb
+  if(allocated(flux%sw_up_clear)) flux%sw_up_clear(:,:) = 0._jprb
+  if(allocated(flux%sw_dn_clear)) flux%sw_dn_clear(:,:) = 0._jprb
+  if(allocated(flux%sw_dn_direct_clear)) flux%sw_dn_direct_clear(:,:) = 0._jprb
 
-  flux%lw_dn_surf_canopy(:,:) = 0._jprb
-  flux%sw_dn_diffuse_surf_canopy(:,:) = 0._jprb
-  flux%sw_dn_direct_surf_canopy(:,:) = 0._jprb
-  flux%lw_derivatives(:,:) = 0._jprb
+  if(allocated(flux%lw_dn_surf_canopy)) flux%lw_dn_surf_canopy(:,:) = 0._jprb
+  if(allocated(flux%sw_dn_diffuse_surf_canopy)) flux%sw_dn_diffuse_surf_canopy(:,:) = 0._jprb
+  if(allocated(flux%sw_dn_direct_surf_canopy)) flux%sw_dn_direct_surf_canopy(:,:) = 0._jprb
+  if(allocated(flux%lw_derivatives)) flux%lw_derivatives(:,:) = 0._jprb
 
   ! Allocate memory for additional arrays
   allocate(ccn_land(ncol))

--- a/driver/ecrad_ifs_driver_blocked.F90
+++ b/driver/ecrad_ifs_driver_blocked.F90
@@ -485,21 +485,28 @@ program ecrad_ifs_driver
   ! "up" fluxes are actually net fluxes at this point - we modify the
   ! upwelling flux so that net=dn-up, while the TOA and surface
   ! downwelling fluxes are correct.
-  flux%sw_up = -flux%sw_up
-  flux%sw_up(:,1) = flux%sw_up(:,1)+flux%sw_dn(:,1)
-  flux%sw_up(:,nlev+1) = flux%sw_up(:,nlev+1)+flux%sw_dn(:,nlev+1)
+  if(yradiation%rad_config%do_sw) then
+    flux%sw_up = -flux%sw_up
+    flux%sw_up(:,1) = flux%sw_up(:,1)+flux%sw_dn(:,1)
+    flux%sw_up(:,nlev+1) = flux%sw_up(:,nlev+1)+flux%sw_dn(:,nlev+1)
+    if(yradiation%rad_config%do_clear) then
+      flux%sw_up_clear = -flux%sw_up_clear
+      flux%sw_up_clear(:,1) = flux%sw_up_clear(:,1)+flux%sw_dn_clear(:,1)
+      flux%sw_up_clear(:,nlev+1) = flux%sw_up_clear(:,nlev+1)+flux%sw_dn_clear(:,nlev+1)
+    endif
 
-  flux%lw_up = -flux%lw_up
-  flux%lw_up(:,1) = flux%lw_up(:,1)+flux%lw_dn(:,1)
-  flux%lw_up(:,nlev+1) = flux%lw_up(:,nlev+1)+flux%lw_dn(:,nlev+1)
+  endif
 
-  flux%sw_up_clear = -flux%sw_up_clear
-  flux%sw_up_clear(:,1) = flux%sw_up_clear(:,1)+flux%sw_dn_clear(:,1)
-  flux%sw_up_clear(:,nlev+1) = flux%sw_up_clear(:,nlev+1)+flux%sw_dn_clear(:,nlev+1)
-
-  flux%lw_up_clear = -flux%lw_up_clear
-  flux%lw_up_clear(:,1) = flux%lw_up_clear(:,1)+flux%lw_dn_clear(:,1)
-  flux%lw_up_clear(:,nlev+1) = flux%lw_up_clear(:,nlev+1)+flux%lw_dn_clear(:,nlev+1)
+  if(yradiation%rad_config%do_lw) then
+    flux%lw_up = -flux%lw_up
+    flux%lw_up(:,1) = flux%lw_up(:,1)+flux%lw_dn(:,1)
+    flux%lw_up(:,nlev+1) = flux%lw_up(:,nlev+1)+flux%lw_dn(:,nlev+1)
+    if(yradiation%rad_config%do_clear) then
+      flux%lw_up_clear = -flux%lw_up_clear
+      flux%lw_up_clear(:,1) = flux%lw_up_clear(:,1)+flux%lw_dn_clear(:,1)
+      flux%lw_up_clear(:,nlev+1) = flux%lw_up_clear(:,nlev+1)+flux%lw_dn_clear(:,nlev+1)
+    endif
+  endif
 
   ! --------------------------------------------------------
   ! Section 5: Check and save output


### PR DESCRIPTION
This fixes the use of unallocated fluxes during initialization (reported in #43) and before output in the IFS-style drivers ecrad_ifs/ecrad_ifs_blocked.

In addition, when switching off aerosols, the number of aerosol types, which is passed to radiation_scheme, cannot be derived from the shape of the mixing ratios array. Thanks to @wertysas for reporting this.