### PR TITLE
roctx cmake fix

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -128,6 +128,7 @@ ecbuild_add_option(
   DEFAULT OFF
   DESCRIPTION "Enable Roctx markers in code"
   CONDITION (HAVE_GPU AND HAVE_OMP)
+  REQUIRED_PACKAGES ROCTX
 )
 
 if( HAVE_ROCTX )

--- a/driver/CMakeLists.txt
+++ b/driver/CMakeLists.txt
@@ -40,7 +40,7 @@ ecbuild_add_executable(
         ifs.${PREC}
         driver_lib.${PREC}
         $<${HAVE_NVTX}:${NVTX_TARGET}>
-        $<${HAVE_ROCTX}:${ECRAD_GPU_ROCPROFILER_SDK_LIBRARIES}>
+        $<${HAVE_ROCTX}:${ROCTX_LIBRARIES}>
     LINKER_LANGUAGE Fortran
 )
 
@@ -53,7 +53,7 @@ ecbuild_add_executable(
         ifs.${PREC}
         driver_lib.${PREC}
         $<${HAVE_NVTX}:${NVTX_TARGET}>
-        $<${HAVE_ROCTX}:${ECRAD_GPU_ROCPROFILER_SDK_LIBRARIES}>
+        $<${HAVE_ROCTX}:${ROCTX_LIBRARIES}>
     LINKER_LANGUAGE Fortran
 )
 

--- a/ifs/CMakeLists.txt
+++ b/ifs/CMakeLists.txt
@@ -31,6 +31,6 @@ ecbuild_add_library(
         ecrad_utilities.${PREC}
     PUBLIC_LIBS
         $<${HAVE_NVTX}:${NVTX_TARGET}>
-        $<${HAVE_ROCTX}:${ECRAD_GPU_ROCPROFILER_SDK_LIBRARIES}>
+        $<${HAVE_ROCTX}:${ROCTX_LIBRARIES}>
     PRIVATE_DEFINITIONS ${GPU_OFFLOAD}GPU
 )

--- a/ifsrrtm/CMakeLists.txt
+++ b/ifsrrtm/CMakeLists.txt
@@ -231,7 +231,7 @@ ecbuild_add_library(
         ecrad_ifsaux.${PREC}
     PUBLIC_LIBS
         $<${HAVE_ACC}:OpenACC::OpenACC_Fortran>
-        $<${HAVE_ROCTX}:${ECRAD_GPU_ROCPROFILER_SDK_LIBRARIES}>
+        $<${HAVE_ROCTX}:${ROCTX_LIBRARIES}>
     PRIVATE_DEFINITIONS ${GPU_OFFLOAD}GPU
 )
 

--- a/radiation/CMakeLists.txt
+++ b/radiation/CMakeLists.txt
@@ -101,7 +101,7 @@ ecbuild_add_library(
     PUBLIC_LIBS
         $<${HAVE_ACC}:OpenACC::OpenACC_Fortran>
         $<${HAVE_NVTX}:${NVTX_TARGET}>
-        $<${HAVE_ROCTX}:${ECRAD_GPU_ROCPROFILER_SDK_LIBRARIES}>
+        $<${HAVE_ROCTX}:${ROCTX_LIBRARIES}>
     PRIVATE_DEFINITIONS ${GPU_OFFLOAD}GPU
 )
 


### PR DESCRIPTION
The previous version was causing linker errors when actually using roctx. It's now fixed.