### PR TITLE
rrtm taumol array computation workaround

### DIFF
--- a/ifsrrtm/rrtm_taumol12.F90
+++ b/ifsrrtm/rrtm_taumol12.F90
@@ -237,6 +237,17 @@ INTEGER(KIND=JPIM) :: llaytrop_min, llaytrop_max
           endif
 
           if (specparm .lt. 0.125_JPRB) then
+#if defined(__amdflang__) && defined(OMPGPU)
+            do ig = 1, ng12
+            tau_major(ig) = speccomb *    &
+             (fac000 * absa(ind0,ig)    + &
+              fac100 * absa(ind0+1,ig)  + &
+              fac200 * absa(ind0+2,ig)  + &
+              fac010 * absa(ind0+9,ig)  + &
+              fac110 * absa(ind0+10,ig) + &
+              fac210 * absa(ind0+11,ig))
+            end do
+#else
 !$NEC unroll(NG12)
             tau_major(1:ng12) = speccomb *    &
              (fac000 * absa(ind0,1:ng12)    + &
@@ -245,7 +256,19 @@ INTEGER(KIND=JPIM) :: llaytrop_min, llaytrop_max
               fac010 * absa(ind0+9,1:ng12)  + &
               fac110 * absa(ind0+10,1:ng12) + &
               fac210 * absa(ind0+11,1:ng12))
+#endif
           else if (specparm .gt. 0.875_JPRB) then
+#if defined(__amdflang__) && defined(OMPGPU)
+            do ig = 1, ng12
+            tau_major(ig) = speccomb *   &
+             (fac200 * absa(ind0-1,ig) + &
+              fac100 * absa(ind0,ig)   + &
+              fac000 * absa(ind0+1,ig) + &
+              fac210 * absa(ind0+8,ig) + &
+              fac110 * absa(ind0+9,ig) + &
+              fac010 * absa(ind0+10,ig))
+            end do
+#else
 !$NEC unroll(NG12)
             tau_major(1:ng12) = speccomb *   &
              (fac200 * absa(ind0-1,1:ng12) + &
@@ -254,16 +277,38 @@ INTEGER(KIND=JPIM) :: llaytrop_min, llaytrop_max
               fac210 * absa(ind0+8,1:ng12) + &
               fac110 * absa(ind0+9,1:ng12) + &
               fac010 * absa(ind0+10,1:ng12))
+#endif
           else
+#if defined(__amdflang__) && defined(OMPGPU)
+            do ig = 1, ng12
+            tau_major(ig) = speccomb *   &
+             (fac000 * absa(ind0,ig)   + &
+              fac100 * absa(ind0+1,ig) + &
+              fac010 * absa(ind0+9,ig) + &
+              fac110 * absa(ind0+10,ig))
+            end do
+#else
 !$NEC unroll(NG12)
             tau_major(1:ng12) = speccomb *   &
              (fac000 * absa(ind0,1:ng12)   + &
               fac100 * absa(ind0+1,1:ng12) + &
               fac010 * absa(ind0+9,1:ng12) + &
               fac110 * absa(ind0+10,1:ng12))
+#endif
           endif
 
           if (specparm1 .lt. 0.125_JPRB) then
+#if defined(__amdflang__) && defined(OMPGPU)
+            do ig = 1, ng12
+            tau_major1(ig) = speccomb1 *  &
+             (fac001 * absa(ind1,ig)    + &
+              fac101 * absa(ind1+1,ig)  + &
+              fac201 * absa(ind1+2,ig)  + &
+              fac011 * absa(ind1+9,ig)  + &
+              fac111 * absa(ind1+10,ig) + &
+              fac211 * absa(ind1+11,ig))
+            end do
+#else
 !$NEC unroll(NG12)
             tau_major1(1:ng12) = speccomb1 *  &
              (fac001 * absa(ind1,1:ng12)    + &
@@ -272,7 +317,19 @@ INTEGER(KIND=JPIM) :: llaytrop_min, llaytrop_max
               fac011 * absa(ind1+9,1:ng12)  + &
               fac111 * absa(ind1+10,1:ng12) + &
               fac211 * absa(ind1+11,1:ng12))
+#endif
           else if (specparm1 .gt. 0.875_JPRB) then
+#if defined(__amdflang__) && defined(OMPGPU)
+            do ig = 1, ng12
+            tau_major1(ig) = speccomb1 * &
+             (fac201 * absa(ind1-1,ig) + &
+              fac101 * absa(ind1,ig)   + &
+              fac001 * absa(ind1+1,ig) + &
+              fac211 * absa(ind1+8,ig) + &
+              fac111 * absa(ind1+9,ig) + &
+              fac011 * absa(ind1+10,ig))
+            end do
+#else
 !$NEC unroll(NG12)
             tau_major1(1:ng12) = speccomb1 * &
              (fac201 * absa(ind1-1,1:ng12) + &
@@ -281,13 +338,24 @@ INTEGER(KIND=JPIM) :: llaytrop_min, llaytrop_max
               fac211 * absa(ind1+8,1:ng12) + &
               fac111 * absa(ind1+9,1:ng12) + &
               fac011 * absa(ind1+10,1:ng12))
+#endif
           else
+#if defined(__amdflang__) && defined(OMPGPU)
+            do ig = 1, ng12
+            tau_major1(ig) = speccomb1 * &
+             (fac001 * absa(ind1,ig)   + &
+              fac101 * absa(ind1+1,ig) + &
+              fac011 * absa(ind1+9,ig) + &
+              fac111 * absa(ind1+10,ig))
+            end do
+#else
 !$NEC unroll(NG12)
             tau_major1(1:ng12) = speccomb1 * &
              (fac001 * absa(ind1,1:ng12)   + &
               fac101 * absa(ind1+1,1:ng12) + &
               fac011 * absa(ind1+9,1:ng12) + &
               fac111 * absa(ind1+10,1:ng12))
+#endif
           endif
 
           !$ACC LOOP SEQ PRIVATE(taufor, tauself)
@@ -439,6 +507,17 @@ INTEGER(KIND=JPIM) :: llaytrop_min, llaytrop_max
             endif
 
             if (specparm .lt. 0.125_JPRB) then
+#if defined(__amdflang__) && defined(OMPGPU)
+            do ig = 1, ng12
+              tau_major(ig) = speccomb *    &
+              (fac000 * absa(ind0,ig)    + &
+                fac100 * absa(ind0+1,ig)  + &
+                fac200 * absa(ind0+2,ig)  + &
+                fac010 * absa(ind0+9,ig)  + &
+                fac110 * absa(ind0+10,ig) + &
+                fac210 * absa(ind0+11,ig))
+            end do
+#else
 !$NEC unroll(NG12)
               tau_major(1:ng12) = speccomb *    &
               (fac000 * absa(ind0,1:ng12)    + &
@@ -447,7 +526,19 @@ INTEGER(KIND=JPIM) :: llaytrop_min, llaytrop_max
                 fac010 * absa(ind0+9,1:ng12)  + &
                 fac110 * absa(ind0+10,1:ng12) + &
                 fac210 * absa(ind0+11,1:ng12))
+#endif
             else if (specparm .gt. 0.875_JPRB) then
+#if defined(__amdflang__) && defined(OMPGPU)
+            do ig = 1, ng12
+              tau_major(ig) = speccomb *   &
+              (fac200 * absa(ind0-1,ig) + &
+                fac100 * absa(ind0,ig)   + &
+                fac000 * absa(ind0+1,ig) + &
+                fac210 * absa(ind0+8,ig) + &
+                fac110 * absa(ind0+9,ig) + &
+                fac010 * absa(ind0+10,ig))
+            end do
+#else
 !$NEC unroll(NG12)
               tau_major(1:ng12) = speccomb *   &
               (fac200 * absa(ind0-1,1:ng12) + &
@@ -456,16 +547,38 @@ INTEGER(KIND=JPIM) :: llaytrop_min, llaytrop_max
                 fac210 * absa(ind0+8,1:ng12) + &
                 fac110 * absa(ind0+9,1:ng12) + &
                 fac010 * absa(ind0+10,1:ng12))
+#endif
             else
+#if defined(__amdflang__) && defined(OMPGPU)
+            do ig = 1, ng12
+              tau_major(ig) = speccomb *   &
+              (fac000 * absa(ind0,ig)   + &
+                fac100 * absa(ind0+1,ig) + &
+                fac010 * absa(ind0+9,ig) + &
+                fac110 * absa(ind0+10,ig))
+            end do
+#else
 !$NEC unroll(NG12)
               tau_major(1:ng12) = speccomb *   &
               (fac000 * absa(ind0,1:ng12)   + &
                 fac100 * absa(ind0+1,1:ng12) + &
                 fac010 * absa(ind0+9,1:ng12) + &
                 fac110 * absa(ind0+10,1:ng12))
+#endif
             endif
 
             if (specparm1 .lt. 0.125_JPRB) then
+#if defined(__amdflang__) && defined(OMPGPU)
+            do ig = 1, ng12
+              tau_major1(ig) = speccomb1 *  &
+              (fac001 * absa(ind1,ig)    + &
+                fac101 * absa(ind1+1,ig)  + &
+                fac201 * absa(ind1+2,ig)  + &
+                fac011 * absa(ind1+9,ig)  + &
+                fac111 * absa(ind1+10,ig) + &
+                fac211 * absa(ind1+11,ig))
+            end do
+#else
 !$NEC unroll(NG12)
               tau_major1(1:ng12) = speccomb1 *  &
               (fac001 * absa(ind1,1:ng12)    + &
@@ -474,7 +587,19 @@ INTEGER(KIND=JPIM) :: llaytrop_min, llaytrop_max
                 fac011 * absa(ind1+9,1:ng12)  + &
                 fac111 * absa(ind1+10,1:ng12) + &
                 fac211 * absa(ind1+11,1:ng12))
+#endif
             else if (specparm1 .gt. 0.875_JPRB) then
+#if defined(__amdflang__) && defined(OMPGPU)
+            do ig = 1, ng12
+              tau_major1(ig) = speccomb1 * &
+              (fac201 * absa(ind1-1,ig) + &
+                fac101 * absa(ind1,ig)   + &
+                fac001 * absa(ind1+1,ig) + &
+                fac211 * absa(ind1+8,ig) + &
+                fac111 * absa(ind1+9,ig) + &
+                fac011 * absa(ind1+10,ig))
+            end do
+#else
 !$NEC unroll(NG12)
               tau_major1(1:ng12) = speccomb1 * &
               (fac201 * absa(ind1-1,1:ng12) + &
@@ -483,13 +608,24 @@ INTEGER(KIND=JPIM) :: llaytrop_min, llaytrop_max
                 fac211 * absa(ind1+8,1:ng12) + &
                 fac111 * absa(ind1+9,1:ng12) + &
                 fac011 * absa(ind1+10,1:ng12))
+#endif
             else
+#if defined(__amdflang__) && defined(OMPGPU)
+            do ig = 1, ng12
+              tau_major1(ig) = speccomb1 * &
+              (fac001 * absa(ind1,ig)   + &
+                fac101 * absa(ind1+1,ig) + &
+                fac011 * absa(ind1+9,ig) + &
+                fac111 * absa(ind1+10,ig))
+            end do
+#else
 !$NEC unroll(NG12)
               tau_major1(1:ng12) = speccomb1 * &
               (fac001 * absa(ind1,1:ng12)   + &
                 fac101 * absa(ind1+1,1:ng12) + &
                 fac011 * absa(ind1+9,1:ng12) + &
                 fac111 * absa(ind1+10,1:ng12))
+#endif
             endif
 
 !$NEC unroll(NG12)

--- a/ifsrrtm/rrtm_taumol13.F90
+++ b/ifsrrtm/rrtm_taumol13.F90
@@ -299,6 +299,17 @@ INTEGER(KIND=JPIM) :: llaytrop_min, llaytrop_max
           endif
 
           if (specparm .lt. 0.125_JPRB) then
+#if defined(__amdflang__) && defined(OMPGPU)
+            do ig = 1, ng13
+            tau_major(ig) = speccomb *    &
+             (fac000 * absa(ind0,ig)    + &
+              fac100 * absa(ind0+1,ig)  + &
+              fac200 * absa(ind0+2,ig)  + &
+              fac010 * absa(ind0+9,ig)  + &
+              fac110 * absa(ind0+10,ig) + &
+              fac210 * absa(ind0+11,ig))
+            end do
+#else
 !$NEC unroll(NG13)
             tau_major(1:ng13) = speccomb *    &
              (fac000 * absa(ind0,1:ng13)    + &
@@ -307,7 +318,19 @@ INTEGER(KIND=JPIM) :: llaytrop_min, llaytrop_max
               fac010 * absa(ind0+9,1:ng13)  + &
               fac110 * absa(ind0+10,1:ng13) + &
               fac210 * absa(ind0+11,1:ng13))
+#endif
           else if (specparm .gt. 0.875_JPRB) then
+#if defined(__amdflang__) && defined(OMPGPU)
+            do ig = 1, ng13
+            tau_major(ig) = speccomb *   &
+             (fac200 * absa(ind0-1,ig) + &
+              fac100 * absa(ind0,ig)   + &
+              fac000 * absa(ind0+1,ig) + &
+              fac210 * absa(ind0+8,ig) + &
+              fac110 * absa(ind0+9,ig) + &
+              fac010 * absa(ind0+10,ig))
+            end do
+#else
 !$NEC unroll(NG13)
             tau_major(1:ng13) = speccomb *   &
              (fac200 * absa(ind0-1,1:ng13) + &
@@ -316,16 +339,38 @@ INTEGER(KIND=JPIM) :: llaytrop_min, llaytrop_max
               fac210 * absa(ind0+8,1:ng13) + &
               fac110 * absa(ind0+9,1:ng13) + &
               fac010 * absa(ind0+10,1:ng13))
+#endif
           else
+#if defined(__amdflang__) && defined(OMPGPU)
+            do ig = 1, ng13
+            tau_major(ig) = speccomb *   &
+             (fac000 * absa(ind0,ig)   + &
+              fac100 * absa(ind0+1,ig) + &
+              fac010 * absa(ind0+9,ig) + &
+              fac110 * absa(ind0+10,ig))
+            end do
+#else
 !$NEC unroll(NG13)
             tau_major(1:ng13) = speccomb *   &
              (fac000 * absa(ind0,1:ng13)   + &
               fac100 * absa(ind0+1,1:ng13) + &
               fac010 * absa(ind0+9,1:ng13) + &
               fac110 * absa(ind0+10,1:ng13))
+#endif
           endif
 
           if (specparm1 .lt. 0.125_JPRB) then
+#if defined(__amdflang__) && defined(OMPGPU)
+            do ig = 1, ng13
+            tau_major1(ig) = speccomb1 *  &
+             (fac001 * absa(ind1,ig)    + &
+              fac101 * absa(ind1+1,ig)  + &
+              fac201 * absa(ind1+2,ig)  + &
+              fac011 * absa(ind1+9,ig)  + &
+              fac111 * absa(ind1+10,ig) + &
+              fac211 * absa(ind1+11,ig))
+            end do
+#else
 !$NEC unroll(NG13)
             tau_major1(1:ng13) = speccomb1 *  &
              (fac001 * absa(ind1,1:ng13)    + &
@@ -334,7 +379,19 @@ INTEGER(KIND=JPIM) :: llaytrop_min, llaytrop_max
               fac011 * absa(ind1+9,1:ng13)  + &
               fac111 * absa(ind1+10,1:ng13) + &
               fac211 * absa(ind1+11,1:ng13))
+#endif
           else if (specparm1 .gt. 0.875_JPRB) then
+#if defined(__amdflang__) && defined(OMPGPU)
+            do ig = 1, ng13
+            tau_major1(ig) = speccomb1 * &
+             (fac201 * absa(ind1-1,ig) + &
+              fac101 * absa(ind1,ig)   + &
+              fac001 * absa(ind1+1,ig) + &
+              fac211 * absa(ind1+8,ig) + &
+              fac111 * absa(ind1+9,ig) + &
+              fac011 * absa(ind1+10,ig))
+            end do
+#else
 !$NEC unroll(NG13)
             tau_major1(1:ng13) = speccomb1 * &
              (fac201 * absa(ind1-1,1:ng13) + &
@@ -343,13 +400,24 @@ INTEGER(KIND=JPIM) :: llaytrop_min, llaytrop_max
               fac211 * absa(ind1+8,1:ng13) + &
               fac111 * absa(ind1+9,1:ng13) + &
               fac011 * absa(ind1+10,1:ng13))
+#endif
           else
+#if defined(__amdflang__) && defined(OMPGPU)
+            do ig = 1, ng13
+            tau_major1(ig) = speccomb1 * &
+             (fac001 * absa(ind1,ig)   + &
+              fac101 * absa(ind1+1,ig) + &
+              fac011 * absa(ind1+9,ig) + &
+              fac111 * absa(ind1+10,ig))
+            end do
+#else
 !$NEC unroll(NG13)
             tau_major1(1:ng13) = speccomb1 * &
              (fac001 * absa(ind1,1:ng13)   + &
               fac101 * absa(ind1+1,1:ng13) + &
               fac011 * absa(ind1+9,1:ng13) + &
               fac111 * absa(ind1+10,1:ng13))
+#endif
           endif
 
           !$ACC LOOP SEQ PRIVATE(taufor, tauself, co2m1, co2m2, absco2, &
@@ -548,6 +616,17 @@ INTEGER(KIND=JPIM) :: llaytrop_min, llaytrop_max
             endif
 
             if (specparm .lt. 0.125_JPRB) then
+#if defined(__amdflang__) && defined(OMPGPU)
+            do ig = 1, ng13
+              tau_major(ig) = speccomb *    &
+              (fac000 * absa(ind0,ig)    + &
+                fac100 * absa(ind0+1,ig)  + &
+                fac200 * absa(ind0+2,ig)  + &
+                fac010 * absa(ind0+9,ig)  + &
+                fac110 * absa(ind0+10,ig) + &
+                fac210 * absa(ind0+11,ig))
+            end do
+#else
 !$NEC unroll(NG13)
               tau_major(1:ng13) = speccomb *    &
               (fac000 * absa(ind0,1:ng13)    + &
@@ -556,7 +635,19 @@ INTEGER(KIND=JPIM) :: llaytrop_min, llaytrop_max
                 fac010 * absa(ind0+9,1:ng13)  + &
                 fac110 * absa(ind0+10,1:ng13) + &
                 fac210 * absa(ind0+11,1:ng13))
+#endif
             else if (specparm .gt. 0.875_JPRB) then
+#if defined(__amdflang__) && defined(OMPGPU)
+            do ig = 1, ng13
+              tau_major(ig) = speccomb *   &
+              (fac200 * absa(ind0-1,ig) + &
+                fac100 * absa(ind0,ig)   + &
+                fac000 * absa(ind0+1,ig) + &
+                fac210 * absa(ind0+8,ig) + &
+                fac110 * absa(ind0+9,ig) + &
+                fac010 * absa(ind0+10,ig))
+            end do
+#else
 !$NEC unroll(NG13)
               tau_major(1:ng13) = speccomb *   &
               (fac200 * absa(ind0-1,1:ng13) + &
@@ -565,16 +656,38 @@ INTEGER(KIND=JPIM) :: llaytrop_min, llaytrop_max
                 fac210 * absa(ind0+8,1:ng13) + &
                 fac110 * absa(ind0+9,1:ng13) + &
                 fac010 * absa(ind0+10,1:ng13))
+#endif
             else
+#if defined(__amdflang__) && defined(OMPGPU)
+            do ig = 1, ng13
+              tau_major(ig) = speccomb *   &
+              (fac000 * absa(ind0,ig)   + &
+                fac100 * absa(ind0+1,ig) + &
+                fac010 * absa(ind0+9,ig) + &
+                fac110 * absa(ind0+10,ig))
+            end do
+#else
 !$NEC unroll(NG13)
               tau_major(1:ng13) = speccomb *   &
               (fac000 * absa(ind0,1:ng13)   + &
                 fac100 * absa(ind0+1,1:ng13) + &
                 fac010 * absa(ind0+9,1:ng13) + &
                 fac110 * absa(ind0+10,1:ng13))
+#endif
             endif
 
             if (specparm1 .lt. 0.125_JPRB) then
+#if defined(__amdflang__) && defined(OMPGPU)
+            do ig = 1, ng13
+              tau_major1(ig) = speccomb1 *  &
+              (fac001 * absa(ind1,ig)    + &
+                fac101 * absa(ind1+1,ig)  + &
+                fac201 * absa(ind1+2,ig)  + &
+                fac011 * absa(ind1+9,ig)  + &
+                fac111 * absa(ind1+10,ig) + &
+                fac211 * absa(ind1+11,ig))
+            end do
+#else
 !$NEC unroll(NG13)
               tau_major1(1:ng13) = speccomb1 *  &
               (fac001 * absa(ind1,1:ng13)    + &
@@ -583,7 +696,19 @@ INTEGER(KIND=JPIM) :: llaytrop_min, llaytrop_max
                 fac011 * absa(ind1+9,1:ng13)  + &
                 fac111 * absa(ind1+10,1:ng13) + &
                 fac211 * absa(ind1+11,1:ng13))
+#endif
             else if (specparm1 .gt. 0.875_JPRB) then
+#if defined(__amdflang__) && defined(OMPGPU)
+            do ig = 1, ng13
+              tau_major1(ig) = speccomb1 * &
+              (fac201 * absa(ind1-1,ig) + &
+                fac101 * absa(ind1,ig)   + &
+                fac001 * absa(ind1+1,ig) + &
+                fac211 * absa(ind1+8,ig) + &
+                fac111 * absa(ind1+9,ig) + &
+                fac011 * absa(ind1+10,ig))
+            end do
+#else
 !$NEC unroll(NG13)
               tau_major1(1:ng13) = speccomb1 * &
               (fac201 * absa(ind1-1,1:ng13) + &
@@ -592,13 +717,24 @@ INTEGER(KIND=JPIM) :: llaytrop_min, llaytrop_max
                 fac211 * absa(ind1+8,1:ng13) + &
                 fac111 * absa(ind1+9,1:ng13) + &
                 fac011 * absa(ind1+10,1:ng13))
+#endif
             else
+#if defined(__amdflang__) && defined(OMPGPU)
+            do ig = 1, ng13
+              tau_major1(ig) = speccomb1 * &
+              (fac001 * absa(ind1,ig)   + &
+                fac101 * absa(ind1+1,ig) + &
+                fac011 * absa(ind1+9,ig) + &
+                fac111 * absa(ind1+10,ig))
+            end do
+#else
 !$NEC unroll(NG13)
               tau_major1(1:ng13) = speccomb1 * &
               (fac001 * absa(ind1,1:ng13)   + &
                 fac101 * absa(ind1+1,1:ng13) + &
                 fac011 * absa(ind1+9,1:ng13) + &
                 fac111 * absa(ind1+10,1:ng13))
+#endif
             endif
 
 !$NEC unroll(NG13)

--- a/ifsrrtm/rrtm_taumol15.F90
+++ b/ifsrrtm/rrtm_taumol15.F90
@@ -272,6 +272,17 @@ INTEGER(KIND=JPIM) :: llaytrop_min, llaytrop_max
           endif
 
           if (specparm .lt. 0.125_JPRB) then
+#if defined(__amdflang__) && defined(OMPGPU)
+            do ig = 1, ng15
+            tau_major(ig) = speccomb *    &
+             (fac000 * absa(ind0,ig)    + &
+              fac100 * absa(ind0+1,ig)  + &
+              fac200 * absa(ind0+2,ig)  + &
+              fac010 * absa(ind0+9,ig)  + &
+              fac110 * absa(ind0+10,ig) + &
+              fac210 * absa(ind0+11,ig))
+            end do
+#else
 !$NEC unroll(NG15)
             tau_major(1:ng15) = speccomb *    &
              (fac000 * absa(ind0,1:ng15)    + &
@@ -280,7 +291,19 @@ INTEGER(KIND=JPIM) :: llaytrop_min, llaytrop_max
               fac010 * absa(ind0+9,1:ng15)  + &
               fac110 * absa(ind0+10,1:ng15) + &
               fac210 * absa(ind0+11,1:ng15))
+#endif
           else if (specparm .gt. 0.875_JPRB) then
+#if defined(__amdflang__) && defined(OMPGPU)
+            do ig = 1, ng15
+            tau_major(ig) = speccomb *   &
+             (fac200 * absa(ind0-1,ig) + &
+              fac100 * absa(ind0,ig)   + &
+              fac000 * absa(ind0+1,ig) + &
+              fac210 * absa(ind0+8,ig) + &
+              fac110 * absa(ind0+9,ig) + &
+              fac010 * absa(ind0+10,ig))
+            end do
+#else
 !$NEC unroll(NG15)
             tau_major(1:ng15) = speccomb *   &
              (fac200 * absa(ind0-1,1:ng15) + &
@@ -289,16 +312,38 @@ INTEGER(KIND=JPIM) :: llaytrop_min, llaytrop_max
               fac210 * absa(ind0+8,1:ng15) + &
               fac110 * absa(ind0+9,1:ng15) + &
               fac010 * absa(ind0+10,1:ng15))
+#endif
           else
+#if defined(__amdflang__) && defined(OMPGPU)
+            do ig = 1, ng15
+            tau_major(ig) = speccomb *   &
+             (fac000 * absa(ind0,ig)   + &
+              fac100 * absa(ind0+1,ig) + &
+              fac010 * absa(ind0+9,ig) + &
+              fac110 * absa(ind0+10,ig))
+            end do
+#else
 !$NEC unroll(NG15)
             tau_major(1:ng15) = speccomb *   &
              (fac000 * absa(ind0,1:ng15)   + &
               fac100 * absa(ind0+1,1:ng15) + &
               fac010 * absa(ind0+9,1:ng15) + &
               fac110 * absa(ind0+10,1:ng15))
+#endif
           endif
 
           if (specparm1 .lt. 0.125_JPRB) then
+#if defined(__amdflang__) && defined(OMPGPU)
+            do ig = 1, ng15
+            tau_major1(ig) = speccomb1 *  &
+             (fac001 * absa(ind1,ig)    + &
+              fac101 * absa(ind1+1,ig)  + &
+              fac201 * absa(ind1+2,ig)  + &
+              fac011 * absa(ind1+9,ig)  + &
+              fac111 * absa(ind1+10,ig) + &
+              fac211 * absa(ind1+11,ig))
+            end do
+#else
 !$NEC unroll(NG15)
             tau_major1(1:ng15) = speccomb1 *  &
              (fac001 * absa(ind1,1:ng15)    + &
@@ -307,7 +352,19 @@ INTEGER(KIND=JPIM) :: llaytrop_min, llaytrop_max
               fac011 * absa(ind1+9,1:ng15)  + &
               fac111 * absa(ind1+10,1:ng15) + &
               fac211 * absa(ind1+11,1:ng15))
+#endif
           else if (specparm1 .gt. 0.875_JPRB) then
+#if defined(__amdflang__) && defined(OMPGPU)
+            do ig = 1, ng15
+            tau_major1(ig) = speccomb1 * &
+             (fac201 * absa(ind1-1,ig) + &
+              fac101 * absa(ind1,ig)   + &
+              fac001 * absa(ind1+1,ig) + &
+              fac211 * absa(ind1+8,ig) + &
+              fac111 * absa(ind1+9,ig) + &
+              fac011 * absa(ind1+10,ig))
+            end do
+#else
 !$NEC unroll(NG15)
             tau_major1(1:ng15) = speccomb1 * &
              (fac201 * absa(ind1-1,1:ng15) + &
@@ -316,13 +373,24 @@ INTEGER(KIND=JPIM) :: llaytrop_min, llaytrop_max
               fac211 * absa(ind1+8,1:ng15) + &
               fac111 * absa(ind1+9,1:ng15) + &
               fac011 * absa(ind1+10,1:ng15))
+#endif
           else
+#if defined(__amdflang__) && defined(OMPGPU)
+            do ig = 1, ng15
+            tau_major1(ig) = speccomb1 * &
+             (fac001 * absa(ind1,ig)   + &
+              fac101 * absa(ind1+1,ig) + &
+              fac011 * absa(ind1+9,ig) + &
+              fac111 * absa(ind1+10,ig))
+            end do
+#else
 !$NEC unroll(NG15)
             tau_major1(1:ng15) = speccomb1 * &
              (fac001 * absa(ind1,1:ng15)   + &
               fac101 * absa(ind1+1,1:ng15) + &
               fac011 * absa(ind1+9,1:ng15) + &
               fac111 * absa(ind1+10,1:ng15))
+#endif
           endif
 
           !$ACC LOOP SEQ PRIVATE(taufor, tauself, n2m1, n2m2, taun2)
@@ -489,6 +557,17 @@ INTEGER(KIND=JPIM) :: llaytrop_min, llaytrop_max
             endif
 
             if (specparm .lt. 0.125_JPRB) then
+#if defined(__amdflang__) && defined(OMPGPU)
+            do ig = 1, ng15
+              tau_major(ig) = speccomb *    &
+              (fac000 * absa(ind0,ig)    + &
+                fac100 * absa(ind0+1,ig)  + &
+                fac200 * absa(ind0+2,ig)  + &
+                fac010 * absa(ind0+9,ig)  + &
+                fac110 * absa(ind0+10,ig) + &
+                fac210 * absa(ind0+11,ig))
+            end do
+#else
 !$NEC unroll(NG15)
               tau_major(1:ng15) = speccomb *    &
               (fac000 * absa(ind0,1:ng15)    + &
@@ -497,7 +576,19 @@ INTEGER(KIND=JPIM) :: llaytrop_min, llaytrop_max
                 fac010 * absa(ind0+9,1:ng15)  + &
                 fac110 * absa(ind0+10,1:ng15) + &
                 fac210 * absa(ind0+11,1:ng15))
+#endif
             else if (specparm .gt. 0.875_JPRB) then
+#if defined(__amdflang__) && defined(OMPGPU)
+            do ig = 1, ng15
+              tau_major(ig) = speccomb *   &
+              (fac200 * absa(ind0-1,ig) + &
+                fac100 * absa(ind0,ig)   + &
+                fac000 * absa(ind0+1,ig) + &
+                fac210 * absa(ind0+8,ig) + &
+                fac110 * absa(ind0+9,ig) + &
+                fac010 * absa(ind0+10,ig))
+            end do
+#else
 !$NEC unroll(NG15)
               tau_major(1:ng15) = speccomb *   &
               (fac200 * absa(ind0-1,1:ng15) + &
@@ -506,16 +597,38 @@ INTEGER(KIND=JPIM) :: llaytrop_min, llaytrop_max
                 fac210 * absa(ind0+8,1:ng15) + &
                 fac110 * absa(ind0+9,1:ng15) + &
                 fac010 * absa(ind0+10,1:ng15))
+#endif
             else
+#if defined(__amdflang__) && defined(OMPGPU)
+            do ig = 1, ng15
+              tau_major(ig) = speccomb *   &
+              (fac000 * absa(ind0,ig)   + &
+                fac100 * absa(ind0+1,ig) + &
+                fac010 * absa(ind0+9,ig) + &
+                fac110 * absa(ind0+10,ig))
+            end do
+#else
 !$NEC unroll(NG15)
               tau_major(1:ng15) = speccomb *   &
               (fac000 * absa(ind0,1:ng15)   + &
                 fac100 * absa(ind0+1,1:ng15) + &
                 fac010 * absa(ind0+9,1:ng15) + &
                 fac110 * absa(ind0+10,1:ng15))
+#endif
             endif
 
             if (specparm1 .lt. 0.125_JPRB) then
+#if defined(__amdflang__) && defined(OMPGPU)
+            do ig = 1, ng15
+              tau_major1(ig) = speccomb1 *  &
+              (fac001 * absa(ind1,ig)    + &
+                fac101 * absa(ind1+1,ig)  + &
+                fac201 * absa(ind1+2,ig)  + &
+                fac011 * absa(ind1+9,ig)  + &
+                fac111 * absa(ind1+10,ig) + &
+                fac211 * absa(ind1+11,ig))
+            end do
+#else
 !$NEC unroll(NG15)
               tau_major1(1:ng15) = speccomb1 *  &
               (fac001 * absa(ind1,1:ng15)    + &
@@ -524,7 +637,19 @@ INTEGER(KIND=JPIM) :: llaytrop_min, llaytrop_max
                 fac011 * absa(ind1+9,1:ng15)  + &
                 fac111 * absa(ind1+10,1:ng15) + &
                 fac211 * absa(ind1+11,1:ng15))
+#endif
             else if (specparm1 .gt. 0.875_JPRB) then
+#if defined(__amdflang__) && defined(OMPGPU)
+            do ig = 1, ng15
+              tau_major1(ig) = speccomb1 * &
+              (fac201 * absa(ind1-1,ig) + &
+                fac101 * absa(ind1,ig)   + &
+                fac001 * absa(ind1+1,ig) + &
+                fac211 * absa(ind1+8,ig) + &
+                fac111 * absa(ind1+9,ig) + &
+                fac011 * absa(ind1+10,ig))
+            end do
+#else
 !$NEC unroll(NG15)
               tau_major1(1:ng15) = speccomb1 * &
               (fac201 * absa(ind1-1,1:ng15) + &
@@ -533,13 +658,24 @@ INTEGER(KIND=JPIM) :: llaytrop_min, llaytrop_max
                 fac211 * absa(ind1+8,1:ng15) + &
                 fac111 * absa(ind1+9,1:ng15) + &
                 fac011 * absa(ind1+10,1:ng15))
+#endif
             else
+#if defined(__amdflang__) && defined(OMPGPU)
+            do ig = 1, ng15
+              tau_major1(ig) = speccomb1 * &
+              (fac001 * absa(ind1,ig)   + &
+                fac101 * absa(ind1+1,ig) + &
+                fac011 * absa(ind1+9,ig) + &
+                fac111 * absa(ind1+10,ig))
+            end do
+#else
 !$NEC unroll(NG15)
               tau_major1(1:ng15) = speccomb1 * &
               (fac001 * absa(ind1,1:ng15)   + &
                 fac101 * absa(ind1+1,1:ng15) + &
                 fac011 * absa(ind1+9,1:ng15) + &
                 fac111 * absa(ind1+10,1:ng15))
+#endif
             endif
 
 !$NEC unroll(NG15)

--- a/ifsrrtm/rrtm_taumol16.F90
+++ b/ifsrrtm/rrtm_taumol16.F90
@@ -230,6 +230,17 @@ INTEGER(KIND=JPIM) :: llaytrop_min, llaytrop_max
           endif
 
           if (specparm .lt. 0.125_JPRB) then
+#if defined(__amdflang__) && defined(OMPGPU)
+            do ig = 1, ng16
+            tau_major(ig) = speccomb *    &
+             (fac000 * absa(ind0,ig)    + &
+              fac100 * absa(ind0+1,ig)  + &
+              fac200 * absa(ind0+2,ig)  + &
+              fac010 * absa(ind0+9,ig)  + &
+              fac110 * absa(ind0+10,ig) + &
+              fac210 * absa(ind0+11,ig))
+            end do
+#else
 !$NEC unroll(NG16)
             tau_major(1:ng16) = speccomb *    &
              (fac000 * absa(ind0,1:ng16)    + &
@@ -238,7 +249,19 @@ INTEGER(KIND=JPIM) :: llaytrop_min, llaytrop_max
               fac010 * absa(ind0+9,1:ng16)  + &
               fac110 * absa(ind0+10,1:ng16) + &
               fac210 * absa(ind0+11,1:ng16))
+#endif
           else if (specparm .gt. 0.875_JPRB) then
+#if defined(__amdflang__) && defined(OMPGPU)
+            do ig = 1, ng16
+            tau_major(ig) = speccomb *   &
+             (fac200 * absa(ind0-1,ig) + &
+              fac100 * absa(ind0,ig)   + &
+              fac000 * absa(ind0+1,ig) + &
+              fac210 * absa(ind0+8,ig) + &
+              fac110 * absa(ind0+9,ig) + &
+              fac010 * absa(ind0+10,ig))
+            end do
+#else
 !$NEC unroll(NG16)
             tau_major(1:ng16) = speccomb *   &
              (fac200 * absa(ind0-1,1:ng16) + &
@@ -247,16 +270,38 @@ INTEGER(KIND=JPIM) :: llaytrop_min, llaytrop_max
               fac210 * absa(ind0+8,1:ng16) + &
               fac110 * absa(ind0+9,1:ng16) + &
               fac010 * absa(ind0+10,1:ng16))
+#endif
           else
+#if defined(__amdflang__) && defined(OMPGPU)
+            do ig = 1, ng16
+             tau_major(ig) = speccomb *   &
+              (fac000 * absa(ind0,ig)   + &
+               fac100 * absa(ind0+1,ig) + &
+               fac010 * absa(ind0+9,ig) + &
+               fac110 * absa(ind0+10,ig))
+            end do
+#else
 !$NEC unroll(NG16)
              tau_major(1:ng16) = speccomb *   &
               (fac000 * absa(ind0,1:ng16)   + &
                fac100 * absa(ind0+1,1:ng16) + &
                fac010 * absa(ind0+9,1:ng16) + &
                fac110 * absa(ind0+10,1:ng16))
+#endif
           endif
 
           if (specparm1 .lt. 0.125_JPRB) then
+#if defined(__amdflang__) && defined(OMPGPU)
+            do ig = 1, ng16
+             tau_major1(ig) = speccomb1 *  &
+              (fac001 * absa(ind1,ig)    + &
+               fac101 * absa(ind1+1,ig)  + &
+               fac201 * absa(ind1+2,ig)  + &
+               fac011 * absa(ind1+9,ig)  + &
+               fac111 * absa(ind1+10,ig) + &
+               fac211 * absa(ind1+11,ig))
+            end do
+#else
 !$NEC unroll(NG16)
              tau_major1(1:ng16) = speccomb1 *  &
               (fac001 * absa(ind1,1:ng16)    + &
@@ -265,7 +310,19 @@ INTEGER(KIND=JPIM) :: llaytrop_min, llaytrop_max
                fac011 * absa(ind1+9,1:ng16)  + &
                fac111 * absa(ind1+10,1:ng16) + &
                fac211 * absa(ind1+11,1:ng16))
+#endif
           else if (specparm1 .gt. 0.875_JPRB) then
+#if defined(__amdflang__) && defined(OMPGPU)
+            do ig = 1, ng16
+            tau_major1(ig) = speccomb1 * &
+             (fac201 * absa(ind1-1,ig) + &
+              fac101 * absa(ind1,ig)   + &
+              fac001 * absa(ind1+1,ig) + &
+              fac211 * absa(ind1+8,ig) + &
+              fac111 * absa(ind1+9,ig) + &
+              fac011 * absa(ind1+10,ig))
+            end do
+#else
 !$NEC unroll(NG16)
             tau_major1(1:ng16) = speccomb1 * &
              (fac201 * absa(ind1-1,1:ng16) + &
@@ -274,13 +331,24 @@ INTEGER(KIND=JPIM) :: llaytrop_min, llaytrop_max
               fac211 * absa(ind1+8,1:ng16) + &
               fac111 * absa(ind1+9,1:ng16) + &
               fac011 * absa(ind1+10,1:ng16))
+#endif
           else
+#if defined(__amdflang__) && defined(OMPGPU)
+            do ig = 1, ng16
+            tau_major1(ig) = speccomb1 * &
+             (fac001 * absa(ind1,ig)   + &
+              fac101 * absa(ind1+1,ig) + &
+              fac011 * absa(ind1+9,ig) + &
+              fac111 * absa(ind1+10,ig))
+            end do
+#else
 !$NEC unroll(NG16)
             tau_major1(1:ng16) = speccomb1 * &
              (fac001 * absa(ind1,1:ng16)   + &
               fac101 * absa(ind1+1,1:ng16) + &
               fac011 * absa(ind1+9,1:ng16) + &
               fac111 * absa(ind1+10,1:ng16))
+#endif
           endif
 
           !$ACC LOOP SEQ PRIVATE(taufor,tauself)
@@ -441,6 +509,17 @@ INTEGER(KIND=JPIM) :: llaytrop_min, llaytrop_max
             endif
 
             if (specparm .lt. 0.125_JPRB) then
+#if defined(__amdflang__) && defined(OMPGPU)
+            do ig = 1, ng16
+              tau_major(ig) = speccomb *    &
+              (fac000 * absa(ind0,ig)    + &
+                fac100 * absa(ind0+1,ig)  + &
+                fac200 * absa(ind0+2,ig)  + &
+                fac010 * absa(ind0+9,ig)  + &
+                fac110 * absa(ind0+10,ig) + &
+                fac210 * absa(ind0+11,ig))
+            end do
+#else
 !$NEC unroll(NG16)
               tau_major(1:ng16) = speccomb *    &
               (fac000 * absa(ind0,1:ng16)    + &
@@ -449,7 +528,19 @@ INTEGER(KIND=JPIM) :: llaytrop_min, llaytrop_max
                 fac010 * absa(ind0+9,1:ng16)  + &
                 fac110 * absa(ind0+10,1:ng16) + &
                 fac210 * absa(ind0+11,1:ng16))
+#endif
             else if (specparm .gt. 0.875_JPRB) then
+#if defined(__amdflang__) && defined(OMPGPU)
+            do ig = 1, ng16
+              tau_major(ig) = speccomb *   &
+              (fac200 * absa(ind0-1,ig) + &
+                fac100 * absa(ind0,ig)   + &
+                fac000 * absa(ind0+1,ig) + &
+                fac210 * absa(ind0+8,ig) + &
+                fac110 * absa(ind0+9,ig) + &
+                fac010 * absa(ind0+10,ig))
+            end do
+#else
 !$NEC unroll(NG16)
               tau_major(1:ng16) = speccomb *   &
               (fac200 * absa(ind0-1,1:ng16) + &
@@ -458,16 +549,38 @@ INTEGER(KIND=JPIM) :: llaytrop_min, llaytrop_max
                 fac210 * absa(ind0+8,1:ng16) + &
                 fac110 * absa(ind0+9,1:ng16) + &
                 fac010 * absa(ind0+10,1:ng16))
+#endif
             else
+#if defined(__amdflang__) && defined(OMPGPU)
+            do ig = 1, ng16
+              tau_major(ig) = speccomb *   &
+                (fac000 * absa(ind0,ig)   + &
+                fac100 * absa(ind0+1,ig) + &
+                fac010 * absa(ind0+9,ig) + &
+                fac110 * absa(ind0+10,ig))
+            end do
+#else
 !$NEC unroll(NG16)
               tau_major(1:ng16) = speccomb *   &
                 (fac000 * absa(ind0,1:ng16)   + &
                 fac100 * absa(ind0+1,1:ng16) + &
                 fac010 * absa(ind0+9,1:ng16) + &
                 fac110 * absa(ind0+10,1:ng16))
+#endif
             endif
 
             if (specparm1 .lt. 0.125_JPRB) then
+#if defined(__amdflang__) && defined(OMPGPU)
+            do ig = 1, ng16
+              tau_major1(ig) = speccomb1 *  &
+                (fac001 * absa(ind1,ig)    + &
+                fac101 * absa(ind1+1,ig)  + &
+                fac201 * absa(ind1+2,ig)  + &
+                fac011 * absa(ind1+9,ig)  + &
+                fac111 * absa(ind1+10,ig) + &
+                fac211 * absa(ind1+11,ig))
+            end do
+#else
 !$NEC unroll(NG16)
               tau_major1(1:ng16) = speccomb1 *  &
                 (fac001 * absa(ind1,1:ng16)    + &
@@ -476,7 +589,19 @@ INTEGER(KIND=JPIM) :: llaytrop_min, llaytrop_max
                 fac011 * absa(ind1+9,1:ng16)  + &
                 fac111 * absa(ind1+10,1:ng16) + &
                 fac211 * absa(ind1+11,1:ng16))
+#endif
             else if (specparm1 .gt. 0.875_JPRB) then
+#if defined(__amdflang__) && defined(OMPGPU)
+            do ig = 1, ng16
+              tau_major1(ig) = speccomb1 * &
+              (fac201 * absa(ind1-1,ig) + &
+                fac101 * absa(ind1,ig)   + &
+                fac001 * absa(ind1+1,ig) + &
+                fac211 * absa(ind1+8,ig) + &
+                fac111 * absa(ind1+9,ig) + &
+                fac011 * absa(ind1+10,ig))
+            end do
+#else
 !$NEC unroll(NG16)
               tau_major1(1:ng16) = speccomb1 * &
               (fac201 * absa(ind1-1,1:ng16) + &
@@ -485,13 +610,24 @@ INTEGER(KIND=JPIM) :: llaytrop_min, llaytrop_max
                 fac211 * absa(ind1+8,1:ng16) + &
                 fac111 * absa(ind1+9,1:ng16) + &
                 fac011 * absa(ind1+10,1:ng16))
+#endif
             else
+#if defined(__amdflang__) && defined(OMPGPU)
+            do ig = 1, ng16
+              tau_major1(ig) = speccomb1 * &
+              (fac001 * absa(ind1,ig)   + &
+                fac101 * absa(ind1+1,ig) + &
+                fac011 * absa(ind1+9,ig) + &
+                fac111 * absa(ind1+10,ig))
+            end do
+#else
 !$NEC unroll(NG16)
               tau_major1(1:ng16) = speccomb1 * &
               (fac001 * absa(ind1,1:ng16)   + &
                 fac101 * absa(ind1+1,1:ng16) + &
                 fac011 * absa(ind1+9,1:ng16) + &
                 fac111 * absa(ind1+10,1:ng16))
+#endif
             endif
 
 !$NEC unroll(NG16)

--- a/ifsrrtm/rrtm_taumol3.F90
+++ b/ifsrrtm/rrtm_taumol3.F90
@@ -277,6 +277,17 @@ INTEGER(KIND=JPIM) :: llaytrop_min, llaytrop_max
           endif
 
           if (specparm .lt. 0.125_JPRB) then
+#if defined(__amdflang__) && defined(OMPGPU)
+            do ig = 1, ng3
+            tau_major(ig) = speccomb *    &
+             (fac000 * absa(ind0,ig)    + &
+              fac100 * absa(ind0+1,ig)  + &
+              fac200 * absa(ind0+2,ig)  + &
+              fac010 * absa(ind0+9,ig)  + &
+              fac110 * absa(ind0+10,ig) + &
+              fac210 * absa(ind0+11,ig))
+            end do
+#else
 !$NEC unroll(NG3)
             tau_major(1:ng3) = speccomb *    &
              (fac000 * absa(ind0,1:ng3)    + &
@@ -285,7 +296,19 @@ INTEGER(KIND=JPIM) :: llaytrop_min, llaytrop_max
               fac010 * absa(ind0+9,1:ng3)  + &
               fac110 * absa(ind0+10,1:ng3) + &
               fac210 * absa(ind0+11,1:ng3))
+#endif
           else if (specparm .gt. 0.875_JPRB) then
+#if defined(__amdflang__) && defined(OMPGPU)
+            do ig = 1, ng3
+            tau_major(ig) = speccomb *   &
+             (fac200 * absa(ind0-1,ig) + &
+              fac100 * absa(ind0,ig)   + &
+              fac000 * absa(ind0+1,ig) + &
+              fac210 * absa(ind0+8,ig) + &
+              fac110 * absa(ind0+9,ig) + &
+              fac010 * absa(ind0+10,ig))
+            end do
+#else
 !$NEC unroll(NG3)
             tau_major(1:ng3) = speccomb *   &
              (fac200 * absa(ind0-1,1:ng3) + &
@@ -294,16 +317,38 @@ INTEGER(KIND=JPIM) :: llaytrop_min, llaytrop_max
               fac210 * absa(ind0+8,1:ng3) + &
               fac110 * absa(ind0+9,1:ng3) + &
               fac010 * absa(ind0+10,1:ng3))
+#endif
           else
+#if defined(__amdflang__) && defined(OMPGPU)
+            do ig = 1, ng3
+            tau_major(ig) = speccomb *   &
+             (fac000 * absa(ind0,ig)   + &
+              fac100 * absa(ind0+1,ig) + &
+              fac010 * absa(ind0+9,ig) + &
+              fac110 * absa(ind0+10,ig))
+            end do
+#else
 !$NEC unroll(NG3)
             tau_major(1:ng3) = speccomb *   &
              (fac000 * absa(ind0,1:ng3)   + &
               fac100 * absa(ind0+1,1:ng3) + &
               fac010 * absa(ind0+9,1:ng3) + &
               fac110 * absa(ind0+10,1:ng3))
+#endif
           endif
 
           if (specparm1 .lt. 0.125_JPRB) then
+#if defined(__amdflang__) && defined(OMPGPU)
+            do ig = 1, ng3
+            tau_major1(ig) = speccomb1 *  &
+             (fac001 * absa(ind1,ig)    + &
+              fac101 * absa(ind1+1,ig)  + &
+              fac201 * absa(ind1+2,ig)  + &
+              fac011 * absa(ind1+9,ig)  + &
+              fac111 * absa(ind1+10,ig) + &
+              fac211 * absa(ind1+11,ig))
+            end do
+#else
 !$NEC unroll(NG3)
             tau_major1(1:ng3) = speccomb1 *  &
              (fac001 * absa(ind1,1:ng3)    + &
@@ -312,7 +357,19 @@ INTEGER(KIND=JPIM) :: llaytrop_min, llaytrop_max
               fac011 * absa(ind1+9,1:ng3)  + &
               fac111 * absa(ind1+10,1:ng3) + &
               fac211 * absa(ind1+11,1:ng3))
+#endif
           else if (specparm1 .gt. 0.875_JPRB) then
+#if defined(__amdflang__) && defined(OMPGPU)
+            do ig = 1, ng3
+            tau_major1(ig) = speccomb1 * &
+             (fac201 * absa(ind1-1,ig) + &
+              fac101 * absa(ind1,ig)   + &
+              fac001 * absa(ind1+1,ig) + &
+              fac211 * absa(ind1+8,ig) + &
+              fac111 * absa(ind1+9,ig) + &
+              fac011 * absa(ind1+10,ig))
+            end do
+#else
 !$NEC unroll(NG3)
             tau_major1(1:ng3) = speccomb1 * &
              (fac201 * absa(ind1-1,1:ng3) + &
@@ -321,13 +378,24 @@ INTEGER(KIND=JPIM) :: llaytrop_min, llaytrop_max
               fac211 * absa(ind1+8,1:ng3) + &
               fac111 * absa(ind1+9,1:ng3) + &
               fac011 * absa(ind1+10,1:ng3))
+#endif
           else
+#if defined(__amdflang__) && defined(OMPGPU)
+            do ig = 1, ng3
+            tau_major1(ig) = speccomb1 * &
+             (fac001 * absa(ind1,ig)   + &
+              fac101 * absa(ind1+1,ig) + &
+              fac011 * absa(ind1+9,ig) + &
+              fac111 * absa(ind1+10,ig))
+            end do
+#else
 !$NEC unroll(NG3)
             tau_major1(1:ng3) = speccomb1 * &
              (fac001 * absa(ind1,1:ng3)   + &
               fac101 * absa(ind1+1,1:ng3) + &
               fac011 * absa(ind1+9,1:ng3) + &
               fac111 * absa(ind1+10,1:ng3))
+#endif
           endif
 
           !$ACC LOOP SEQ PRIVATE(tauself, taufor, n2om1, n2om2, absn2o)
@@ -584,6 +652,17 @@ INTEGER(KIND=JPIM) :: llaytrop_min, llaytrop_max
             endif
 
             if (specparm .lt. 0.125_JPRB) then
+#if defined(__amdflang__) && defined(OMPGPU)
+            do ig = 1, ng3
+              tau_major(ig) = speccomb *    &
+              (fac000 * absa(ind0,ig)    + &
+                fac100 * absa(ind0+1,ig)  + &
+                fac200 * absa(ind0+2,ig)  + &
+                fac010 * absa(ind0+9,ig)  + &
+                fac110 * absa(ind0+10,ig) + &
+                fac210 * absa(ind0+11,ig))
+            end do
+#else
 !$NEC unroll(NG3)
               tau_major(1:ng3) = speccomb *    &
               (fac000 * absa(ind0,1:ng3)    + &
@@ -592,7 +671,19 @@ INTEGER(KIND=JPIM) :: llaytrop_min, llaytrop_max
                 fac010 * absa(ind0+9,1:ng3)  + &
                 fac110 * absa(ind0+10,1:ng3) + &
                 fac210 * absa(ind0+11,1:ng3))
+#endif
             else if (specparm .gt. 0.875_JPRB) then
+#if defined(__amdflang__) && defined(OMPGPU)
+            do ig = 1, ng3
+              tau_major(ig) = speccomb *   &
+              (fac200 * absa(ind0-1,ig) + &
+                fac100 * absa(ind0,ig)   + &
+                fac000 * absa(ind0+1,ig) + &
+                fac210 * absa(ind0+8,ig) + &
+                fac110 * absa(ind0+9,ig) + &
+                fac010 * absa(ind0+10,ig))
+            end do
+#else
 !$NEC unroll(NG3)
               tau_major(1:ng3) = speccomb *   &
               (fac200 * absa(ind0-1,1:ng3) + &
@@ -601,16 +692,38 @@ INTEGER(KIND=JPIM) :: llaytrop_min, llaytrop_max
                 fac210 * absa(ind0+8,1:ng3) + &
                 fac110 * absa(ind0+9,1:ng3) + &
                 fac010 * absa(ind0+10,1:ng3))
+#endif
             else
+#if defined(__amdflang__) && defined(OMPGPU)
+            do ig = 1, ng3
+              tau_major(ig) = speccomb *   &
+              (fac000 * absa(ind0,ig)   + &
+                fac100 * absa(ind0+1,ig) + &
+                fac010 * absa(ind0+9,ig) + &
+                fac110 * absa(ind0+10,ig))
+            end do
+#else
 !$NEC unroll(NG3)
               tau_major(1:ng3) = speccomb *   &
               (fac000 * absa(ind0,1:ng3)   + &
                 fac100 * absa(ind0+1,1:ng3) + &
                 fac010 * absa(ind0+9,1:ng3) + &
                 fac110 * absa(ind0+10,1:ng3))
+#endif
             endif
 
             if (specparm1 .lt. 0.125_JPRB) then
+#if defined(__amdflang__) && defined(OMPGPU)
+            do ig = 1, ng3
+              tau_major1(ig) = speccomb1 *  &
+              (fac001 * absa(ind1,ig)    + &
+                fac101 * absa(ind1+1,ig)  + &
+                fac201 * absa(ind1+2,ig)  + &
+                fac011 * absa(ind1+9,ig)  + &
+                fac111 * absa(ind1+10,ig) + &
+                fac211 * absa(ind1+11,ig))
+            end do
+#else
 !$NEC unroll(NG3)
               tau_major1(1:ng3) = speccomb1 *  &
               (fac001 * absa(ind1,1:ng3)    + &
@@ -619,7 +732,19 @@ INTEGER(KIND=JPIM) :: llaytrop_min, llaytrop_max
                 fac011 * absa(ind1+9,1:ng3)  + &
                 fac111 * absa(ind1+10,1:ng3) + &
                 fac211 * absa(ind1+11,1:ng3))
+#endif
             else if (specparm1 .gt. 0.875_JPRB) then
+#if defined(__amdflang__) && defined(OMPGPU)
+            do ig = 1, ng3
+              tau_major1(ig) = speccomb1 * &
+              (fac201 * absa(ind1-1,ig) + &
+                fac101 * absa(ind1,ig)   + &
+                fac001 * absa(ind1+1,ig) + &
+                fac211 * absa(ind1+8,ig) + &
+                fac111 * absa(ind1+9,ig) + &
+                fac011 * absa(ind1+10,ig))
+            end do
+#else
 !$NEC unroll(NG3)
               tau_major1(1:ng3) = speccomb1 * &
               (fac201 * absa(ind1-1,1:ng3) + &
@@ -628,13 +753,24 @@ INTEGER(KIND=JPIM) :: llaytrop_min, llaytrop_max
                 fac211 * absa(ind1+8,1:ng3) + &
                 fac111 * absa(ind1+9,1:ng3) + &
                 fac011 * absa(ind1+10,1:ng3))
+#endif
             else
+#if defined(__amdflang__) && defined(OMPGPU)
+            do ig = 1, ng3
+              tau_major1(ig) = speccomb1 * &
+              (fac001 * absa(ind1,ig)   + &
+                fac101 * absa(ind1+1,ig) + &
+                fac011 * absa(ind1+9,ig) + &
+                fac111 * absa(ind1+10,ig))
+            end do
+#else
 !$NEC unroll(NG3)
               tau_major1(1:ng3) = speccomb1 * &
               (fac001 * absa(ind1,1:ng3)   + &
                 fac101 * absa(ind1+1,1:ng3) + &
                 fac011 * absa(ind1+9,1:ng3) + &
                 fac111 * absa(ind1+10,1:ng3))
+#endif
             endif
 
 !$NEC unroll(NG3)

--- a/ifsrrtm/rrtm_taumol4.F90
+++ b/ifsrrtm/rrtm_taumol4.F90
@@ -244,6 +244,17 @@ INTEGER(KIND=JPIM) :: llaytrop_min, llaytrop_max
           endif
 
           if (specparm .lt. 0.125_JPRB) then
+#if defined(__amdflang__) && defined(OMPGPU)
+            do ig = 1, ng4
+            tau_major(ig) = speccomb *    &
+             (fac000 * absa(ind0,ig)    + &
+              fac100 * absa(ind0+1,ig)  + &
+              fac200 * absa(ind0+2,ig)  + &
+              fac010 * absa(ind0+9,ig)  + &
+              fac110 * absa(ind0+10,ig) + &
+              fac210 * absa(ind0+11,ig))
+            enddo
+#else
 !$NEC unroll(NG4)
             tau_major(1:ng4) = speccomb *    &
              (fac000 * absa(ind0,1:ng4)    + &
@@ -252,7 +263,19 @@ INTEGER(KIND=JPIM) :: llaytrop_min, llaytrop_max
               fac010 * absa(ind0+9,1:ng4)  + &
               fac110 * absa(ind0+10,1:ng4) + &
               fac210 * absa(ind0+11,1:ng4))
+#endif
           else if (specparm .gt. 0.875_JPRB) then
+#if defined(__amdflang__) && defined(OMPGPU)
+            do ig = 1, ng4
+            tau_major(ig) = speccomb *   &
+             (fac200 * absa(ind0-1,ig) + &
+              fac100 * absa(ind0,ig)   + &
+              fac000 * absa(ind0+1,ig) + &
+              fac210 * absa(ind0+8,ig) + &
+              fac110 * absa(ind0+9,ig) + &
+              fac010 * absa(ind0+10,ig))
+            enddo
+#else
 !$NEC unroll(NG4)
             tau_major(1:ng4) = speccomb *   &
              (fac200 * absa(ind0-1,1:ng4) + &
@@ -261,16 +284,38 @@ INTEGER(KIND=JPIM) :: llaytrop_min, llaytrop_max
               fac210 * absa(ind0+8,1:ng4) + &
               fac110 * absa(ind0+9,1:ng4) + &
               fac010 * absa(ind0+10,1:ng4))
+#endif
           else
+#if defined(__amdflang__) && defined(OMPGPU)
+            do ig = 1, ng4
+             tau_major(ig) = speccomb *   &
+              (fac000 * absa(ind0,ig)   + &
+               fac100 * absa(ind0+1,ig) + &
+               fac010 * absa(ind0+9,ig) + &
+               fac110 * absa(ind0+10,ig))
+            enddo
+#else
 !$NEC unroll(NG4)
              tau_major(1:ng4) = speccomb *   &
               (fac000 * absa(ind0,1:ng4)   + &
                fac100 * absa(ind0+1,1:ng4) + &
                fac010 * absa(ind0+9,1:ng4) + &
                fac110 * absa(ind0+10,1:ng4))
+#endif
           endif
 
           if (specparm1 .lt. 0.125_JPRB) then
+#if defined(__amdflang__) && defined(OMPGPU)
+            do ig = 1, ng4
+            tau_major1(ig) = speccomb1 *  &
+             (fac001 * absa(ind1,ig)    + &
+              fac101 * absa(ind1+1,ig)  + &
+              fac201 * absa(ind1+2,ig)  + &
+              fac011 * absa(ind1+9,ig)  + &
+              fac111 * absa(ind1+10,ig) + &
+              fac211 * absa(ind1+11,ig))
+            enddo
+#else
 !$NEC unroll(NG4)
             tau_major1(1:ng4) = speccomb1 *  &
              (fac001 * absa(ind1,1:ng4)    + &
@@ -279,7 +324,19 @@ INTEGER(KIND=JPIM) :: llaytrop_min, llaytrop_max
               fac011 * absa(ind1+9,1:ng4)  + &
               fac111 * absa(ind1+10,1:ng4) + &
               fac211 * absa(ind1+11,1:ng4))
+#endif
           else if (specparm1 .gt. 0.875_JPRB) then
+#if defined(__amdflang__) && defined(OMPGPU)
+            do ig = 1, ng4
+            tau_major1(ig) = speccomb1 * &
+             (fac201 * absa(ind1-1,ig) + &
+              fac101 * absa(ind1,ig)   + &
+              fac001 * absa(ind1+1,ig) + &
+              fac211 * absa(ind1+8,ig) + &
+              fac111 * absa(ind1+9,ig) + &
+              fac011 * absa(ind1+10,ig))
+            enddo
+#else
 !$NEC unroll(NG4)
             tau_major1(1:ng4) = speccomb1 * &
              (fac201 * absa(ind1-1,1:ng4) + &
@@ -288,13 +345,24 @@ INTEGER(KIND=JPIM) :: llaytrop_min, llaytrop_max
               fac211 * absa(ind1+8,1:ng4) + &
               fac111 * absa(ind1+9,1:ng4) + &
               fac011 * absa(ind1+10,1:ng4))
+#endif
           else
+#if defined(__amdflang__) && defined(OMPGPU)
+            do ig = 1, ng4
+            tau_major1(ig) = speccomb1 * &
+             (fac001 * absa(ind1,ig)   + &
+              fac101 * absa(ind1+1,ig) + &
+              fac011 * absa(ind1+9,ig) + &
+              fac111 * absa(ind1+10,ig))
+            enddo
+#else
 !$NEC unroll(NG4)
             tau_major1(1:ng4) = speccomb1 * &
              (fac001 * absa(ind1,1:ng4)   + &
               fac101 * absa(ind1+1,1:ng4) + &
               fac011 * absa(ind1+9,1:ng4) + &
               fac111 * absa(ind1+10,1:ng4))
+#endif
           endif
 
           !$ACC LOOP SEQ PRIVATE(taufor, tauself)
@@ -512,6 +580,17 @@ INTEGER(KIND=JPIM) :: llaytrop_min, llaytrop_max
             endif
 
             if (specparm .lt. 0.125_JPRB) then
+#if defined(__amdflang__) && defined(OMPGPU)
+            do ig = 1, ng4
+              tau_major(ig) = speccomb *    &
+              (fac000 * absa(ind0,ig)    + &
+                fac100 * absa(ind0+1,ig)  + &
+                fac200 * absa(ind0+2,ig)  + &
+                fac010 * absa(ind0+9,ig)  + &
+                fac110 * absa(ind0+10,ig) + &
+                fac210 * absa(ind0+11,ig))
+            enddo
+#else
 !$NEC unroll(NG4)
               tau_major(1:ng4) = speccomb *    &
               (fac000 * absa(ind0,1:ng4)    + &
@@ -520,7 +599,19 @@ INTEGER(KIND=JPIM) :: llaytrop_min, llaytrop_max
                 fac010 * absa(ind0+9,1:ng4)  + &
                 fac110 * absa(ind0+10,1:ng4) + &
                 fac210 * absa(ind0+11,1:ng4))
+#endif
             else if (specparm .gt. 0.875_JPRB) then
+#if defined(__amdflang__) && defined(OMPGPU)
+            do ig = 1, ng4
+              tau_major(ig) = speccomb *   &
+              (fac200 * absa(ind0-1,ig) + &
+                fac100 * absa(ind0,ig)   + &
+                fac000 * absa(ind0+1,ig) + &
+                fac210 * absa(ind0+8,ig) + &
+                fac110 * absa(ind0+9,ig) + &
+                fac010 * absa(ind0+10,ig))
+            enddo
+#else
 !$NEC unroll(NG4)
               tau_major(1:ng4) = speccomb *   &
               (fac200 * absa(ind0-1,1:ng4) + &
@@ -529,16 +620,38 @@ INTEGER(KIND=JPIM) :: llaytrop_min, llaytrop_max
                 fac210 * absa(ind0+8,1:ng4) + &
                 fac110 * absa(ind0+9,1:ng4) + &
                 fac010 * absa(ind0+10,1:ng4))
+#endif
             else
+#if defined(__amdflang__) && defined(OMPGPU)
+            do ig = 1, ng4
+              tau_major(ig) = speccomb *   &
+                (fac000 * absa(ind0,ig)   + &
+                fac100 * absa(ind0+1,ig) + &
+                fac010 * absa(ind0+9,ig) + &
+                fac110 * absa(ind0+10,ig))
+            enddo
+#else
 !$NEC unroll(NG4)
               tau_major(1:ng4) = speccomb *   &
                 (fac000 * absa(ind0,1:ng4)   + &
                 fac100 * absa(ind0+1,1:ng4) + &
                 fac010 * absa(ind0+9,1:ng4) + &
                 fac110 * absa(ind0+10,1:ng4))
+#endif
             endif
 
             if (specparm1 .lt. 0.125_JPRB) then
+#if defined(__amdflang__) && defined(OMPGPU)
+            do ig = 1, ng4
+              tau_major1(ig) = speccomb1 *  &
+              (fac001 * absa(ind1,ig)    + &
+                fac101 * absa(ind1+1,ig)  + &
+                fac201 * absa(ind1+2,ig)  + &
+                fac011 * absa(ind1+9,ig)  + &
+                fac111 * absa(ind1+10,ig) + &
+                fac211 * absa(ind1+11,ig))
+            enddo
+#else
 !$NEC unroll(NG4)
               tau_major1(1:ng4) = speccomb1 *  &
               (fac001 * absa(ind1,1:ng4)    + &
@@ -547,7 +660,19 @@ INTEGER(KIND=JPIM) :: llaytrop_min, llaytrop_max
                 fac011 * absa(ind1+9,1:ng4)  + &
                 fac111 * absa(ind1+10,1:ng4) + &
                 fac211 * absa(ind1+11,1:ng4))
+#endif
             else if (specparm1 .gt. 0.875_JPRB) then
+#if defined(__amdflang__) && defined(OMPGPU)
+            do ig = 1, ng4
+              tau_major1(ig) = speccomb1 * &
+              (fac201 * absa(ind1-1,ig) + &
+                fac101 * absa(ind1,ig)   + &
+                fac001 * absa(ind1+1,ig) + &
+                fac211 * absa(ind1+8,ig) + &
+                fac111 * absa(ind1+9,ig) + &
+                fac011 * absa(ind1+10,ig))
+            enddo
+#else
 !$NEC unroll(NG4)
               tau_major1(1:ng4) = speccomb1 * &
               (fac201 * absa(ind1-1,1:ng4) + &
@@ -556,13 +681,24 @@ INTEGER(KIND=JPIM) :: llaytrop_min, llaytrop_max
                 fac211 * absa(ind1+8,1:ng4) + &
                 fac111 * absa(ind1+9,1:ng4) + &
                 fac011 * absa(ind1+10,1:ng4))
+#endif
             else
+#if defined(__amdflang__) && defined(OMPGPU)
+            do ig = 1, ng4
+              tau_major1(ig) = speccomb1 * &
+              (fac001 * absa(ind1,ig)   + &
+                fac101 * absa(ind1+1,ig) + &
+                fac011 * absa(ind1+9,ig) + &
+                fac111 * absa(ind1+10,ig))
+            enddo
+#else
 !$NEC unroll(NG4)
               tau_major1(1:ng4) = speccomb1 * &
               (fac001 * absa(ind1,1:ng4)   + &
                 fac101 * absa(ind1+1,1:ng4) + &
                 fac011 * absa(ind1+9,1:ng4) + &
                 fac111 * absa(ind1+10,1:ng4))
+#endif
             endif
 
 !$NEC unroll(NG4)

--- a/ifsrrtm/rrtm_taumol5.F90
+++ b/ifsrrtm/rrtm_taumol5.F90
@@ -266,6 +266,17 @@ INTEGER(KIND=JPIM) :: llaytrop_min, llaytrop_max
           endif
 
           if (specparm .lt. 0.125_JPRB) then
+#if defined(__amdflang__) && defined(OMPGPU)
+            do ig = 1, ng5
+            tau_major(ig) = speccomb *    &
+             (fac000 * absa(ind0,ig)    + &
+              fac100 * absa(ind0+1,ig)  + &
+              fac200 * absa(ind0+2,ig)  + &
+              fac010 * absa(ind0+9,ig)  + &
+              fac110 * absa(ind0+10,ig) + &
+              fac210 * absa(ind0+11,ig))
+            end do
+#else
 !$NEC unroll(NG5)
             tau_major(1:ng5) = speccomb *    &
              (fac000 * absa(ind0,1:ng5)    + &
@@ -274,7 +285,19 @@ INTEGER(KIND=JPIM) :: llaytrop_min, llaytrop_max
               fac010 * absa(ind0+9,1:ng5)  + &
               fac110 * absa(ind0+10,1:ng5) + &
               fac210 * absa(ind0+11,1:ng5))
+#endif
           else if (specparm .gt. 0.875_JPRB) then
+#if defined(__amdflang__) && defined(OMPGPU)
+            do ig = 1, ng5
+            tau_major(ig) = speccomb *   &
+             (fac200 * absa(ind0-1,ig) + &
+              fac100 * absa(ind0,ig)   + &
+              fac000 * absa(ind0+1,ig) + &
+              fac210 * absa(ind0+8,ig) + &
+              fac110 * absa(ind0+9,ig) + &
+              fac010 * absa(ind0+10,ig))
+            end do
+#else
 !$NEC unroll(NG5)
             tau_major(1:ng5) = speccomb *   &
              (fac200 * absa(ind0-1,1:ng5) + &
@@ -283,16 +306,38 @@ INTEGER(KIND=JPIM) :: llaytrop_min, llaytrop_max
               fac210 * absa(ind0+8,1:ng5) + &
               fac110 * absa(ind0+9,1:ng5) + &
               fac010 * absa(ind0+10,1:ng5))
+#endif
           else
+#if defined(__amdflang__) && defined(OMPGPU)
+            do ig = 1, ng5
+            tau_major(ig) = speccomb *   &
+             (fac000 * absa(ind0,ig)   + &
+              fac100 * absa(ind0+1,ig) + &
+              fac010 * absa(ind0+9,ig) + &
+              fac110 * absa(ind0+10,ig))
+            end do
+#else
 !$NEC unroll(NG5)
             tau_major(1:ng5) = speccomb *   &
              (fac000 * absa(ind0,1:ng5)   + &
               fac100 * absa(ind0+1,1:ng5) + &
               fac010 * absa(ind0+9,1:ng5) + &
               fac110 * absa(ind0+10,1:ng5))
+#endif
           endif
 
           if (specparm1 .lt. 0.125_JPRB) then
+#if defined(__amdflang__) && defined(OMPGPU)
+            do ig = 1, ng5
+            tau_major1(ig) = speccomb1 *  &
+             (fac001 * absa(ind1,ig)    + &
+              fac101 * absa(ind1+1,ig)  + &
+              fac201 * absa(ind1+2,ig)  + &
+              fac011 * absa(ind1+9,ig)  + &
+              fac111 * absa(ind1+10,ig) + &
+              fac211 * absa(ind1+11,ig))
+            end do
+#else
 !$NEC unroll(NG5)
             tau_major1(1:ng5) = speccomb1 *  &
              (fac001 * absa(ind1,1:ng5)    + &
@@ -301,7 +346,19 @@ INTEGER(KIND=JPIM) :: llaytrop_min, llaytrop_max
               fac011 * absa(ind1+9,1:ng5)  + &
               fac111 * absa(ind1+10,1:ng5) + &
               fac211 * absa(ind1+11,1:ng5))
+#endif
           else if (specparm1 .gt. 0.875_JPRB) then
+#if defined(__amdflang__) && defined(OMPGPU)
+            do ig = 1, ng5
+            tau_major1(ig) = speccomb1 * &
+             (fac201 * absa(ind1-1,ig) + &
+              fac101 * absa(ind1,ig)   + &
+              fac001 * absa(ind1+1,ig) + &
+              fac211 * absa(ind1+8,ig) + &
+              fac111 * absa(ind1+9,ig) + &
+              fac011 * absa(ind1+10,ig))
+            end do
+#else
 !$NEC unroll(NG5)
             tau_major1(1:ng5) = speccomb1 * &
              (fac201 * absa(ind1-1,1:ng5) + &
@@ -310,13 +367,24 @@ INTEGER(KIND=JPIM) :: llaytrop_min, llaytrop_max
               fac211 * absa(ind1+8,1:ng5) + &
               fac111 * absa(ind1+9,1:ng5) + &
               fac011 * absa(ind1+10,1:ng5))
+#endif
           else
+#if defined(__amdflang__) && defined(OMPGPU)
+            do ig = 1, ng5
+            tau_major1(ig) = speccomb1 * &
+             (fac001 * absa(ind1,ig)   + &
+              fac101 * absa(ind1+1,ig) + &
+              fac011 * absa(ind1+9,ig) + &
+              fac111 * absa(ind1+10,ig))
+            end do
+#else
 !$NEC unroll(NG5)
             tau_major1(1:ng5) = speccomb1 * &
              (fac001 * absa(ind1,1:ng5)   + &
               fac101 * absa(ind1+1,1:ng5) + &
               fac011 * absa(ind1+9,1:ng5) + &
               fac111 * absa(ind1+10,1:ng5))
+#endif
           endif
 
           !$ACC LOOP SEQ PRIVATE(taufor,tauself, o3m1, o3m2, abso3)
@@ -530,6 +598,17 @@ INTEGER(KIND=JPIM) :: llaytrop_min, llaytrop_max
             endif
 
             if (specparm .lt. 0.125_JPRB) then
+#if defined(__amdflang__) && defined(OMPGPU)
+            do ig = 1, ng5
+              tau_major(ig) = speccomb *    &
+              (fac000 * absa(ind0,ig)    + &
+                fac100 * absa(ind0+1,ig)  + &
+                fac200 * absa(ind0+2,ig)  + &
+                fac010 * absa(ind0+9,ig)  + &
+                fac110 * absa(ind0+10,ig) + &
+                fac210 * absa(ind0+11,ig))
+            end do
+#else
 !$NEC unroll(NG5)
               tau_major(1:ng5) = speccomb *    &
               (fac000 * absa(ind0,1:ng5)    + &
@@ -538,7 +617,19 @@ INTEGER(KIND=JPIM) :: llaytrop_min, llaytrop_max
                 fac010 * absa(ind0+9,1:ng5)  + &
                 fac110 * absa(ind0+10,1:ng5) + &
                 fac210 * absa(ind0+11,1:ng5))
+#endif
             else if (specparm .gt. 0.875_JPRB) then
+#if defined(__amdflang__) && defined(OMPGPU)
+            do ig = 1, ng5
+              tau_major(ig) = speccomb *   &
+              (fac200 * absa(ind0-1,ig) + &
+                fac100 * absa(ind0,ig)   + &
+                fac000 * absa(ind0+1,ig) + &
+                fac210 * absa(ind0+8,ig) + &
+                fac110 * absa(ind0+9,ig) + &
+                fac010 * absa(ind0+10,ig))
+            end do
+#else
 !$NEC unroll(NG5)
               tau_major(1:ng5) = speccomb *   &
               (fac200 * absa(ind0-1,1:ng5) + &
@@ -547,16 +638,38 @@ INTEGER(KIND=JPIM) :: llaytrop_min, llaytrop_max
                 fac210 * absa(ind0+8,1:ng5) + &
                 fac110 * absa(ind0+9,1:ng5) + &
                 fac010 * absa(ind0+10,1:ng5))
+#endif
             else
+#if defined(__amdflang__) && defined(OMPGPU)
+            do ig = 1, ng5
+              tau_major(ig) = speccomb *   &
+              (fac000 * absa(ind0,ig)   + &
+                fac100 * absa(ind0+1,ig) + &
+                fac010 * absa(ind0+9,ig) + &
+                fac110 * absa(ind0+10,ig))
+            end do
+#else
 !$NEC unroll(NG5)
               tau_major(1:ng5) = speccomb *   &
               (fac000 * absa(ind0,1:ng5)   + &
                 fac100 * absa(ind0+1,1:ng5) + &
                 fac010 * absa(ind0+9,1:ng5) + &
                 fac110 * absa(ind0+10,1:ng5))
+#endif
             endif
 
             if (specparm1 .lt. 0.125_JPRB) then
+#if defined(__amdflang__) && defined(OMPGPU)
+            do ig = 1, ng5
+              tau_major1(ig) = speccomb1 *  &
+              (fac001 * absa(ind1,ig)    + &
+                fac101 * absa(ind1+1,ig)  + &
+                fac201 * absa(ind1+2,ig)  + &
+                fac011 * absa(ind1+9,ig)  + &
+                fac111 * absa(ind1+10,ig) + &
+                fac211 * absa(ind1+11,ig))
+            end do
+#else
 !$NEC unroll(NG5)
               tau_major1(1:ng5) = speccomb1 *  &
               (fac001 * absa(ind1,1:ng5)    + &
@@ -565,7 +678,19 @@ INTEGER(KIND=JPIM) :: llaytrop_min, llaytrop_max
                 fac011 * absa(ind1+9,1:ng5)  + &
                 fac111 * absa(ind1+10,1:ng5) + &
                 fac211 * absa(ind1+11,1:ng5))
+#endif
             else if (specparm1 .gt. 0.875_JPRB) then
+#if defined(__amdflang__) && defined(OMPGPU)
+            do ig = 1, ng5
+              tau_major1(ig) = speccomb1 * &
+              (fac201 * absa(ind1-1,ig) + &
+                fac101 * absa(ind1,ig)   + &
+                fac001 * absa(ind1+1,ig) + &
+                fac211 * absa(ind1+8,ig) + &
+                fac111 * absa(ind1+9,ig) + &
+                fac011 * absa(ind1+10,ig))
+            end do
+#else
 !$NEC unroll(NG5)
               tau_major1(1:ng5) = speccomb1 * &
               (fac201 * absa(ind1-1,1:ng5) + &
@@ -574,13 +699,24 @@ INTEGER(KIND=JPIM) :: llaytrop_min, llaytrop_max
                 fac211 * absa(ind1+8,1:ng5) + &
                 fac111 * absa(ind1+9,1:ng5) + &
                 fac011 * absa(ind1+10,1:ng5))
+#endif
             else
+#if defined(__amdflang__) && defined(OMPGPU)
+            do ig = 1, ng5
+              tau_major1(ig) = speccomb1 * &
+              (fac001 * absa(ind1,ig)   + &
+                fac101 * absa(ind1+1,ig) + &
+                fac011 * absa(ind1+9,ig) + &
+                fac111 * absa(ind1+10,ig))
+            end do
+#else
 !$NEC unroll(NG5)
               tau_major1(1:ng5) = speccomb1 * &
               (fac001 * absa(ind1,1:ng5)   + &
                 fac101 * absa(ind1+1,1:ng5) + &
                 fac011 * absa(ind1+9,1:ng5) + &
                 fac111 * absa(ind1+10,1:ng5))
+#endif
             endif
 
 !$NEC unroll(NG5)

--- a/ifsrrtm/rrtm_taumol7.F90
+++ b/ifsrrtm/rrtm_taumol7.F90
@@ -269,6 +269,17 @@ INTEGER(KIND=JPIM) :: llaytrop_min, llaytrop_max
           endif
 
           if (specparm .lt. 0.125_JPRB) then
+#if defined(__amdflang__) && defined(OMPGPU)
+            do ig = 1, ng7
+            tau_major(ig) = speccomb *    &
+             (fac000 * absa(ind0,ig)    + &
+              fac100 * absa(ind0+1,ig)  + &
+              fac200 * absa(ind0+2,ig)  + &
+              fac010 * absa(ind0+9,ig)  + &
+              fac110 * absa(ind0+10,ig) + &
+              fac210 * absa(ind0+11,ig))
+            end do
+#else
 !$NEC unroll(NG7)
             tau_major(1:ng7) = speccomb *    &
              (fac000 * absa(ind0,1:ng7)    + &
@@ -277,7 +288,19 @@ INTEGER(KIND=JPIM) :: llaytrop_min, llaytrop_max
               fac010 * absa(ind0+9,1:ng7)  + &
               fac110 * absa(ind0+10,1:ng7) + &
               fac210 * absa(ind0+11,1:ng7))
+#endif
           else if (specparm .gt. 0.875_JPRB) then
+#if defined(__amdflang__) && defined(OMPGPU)
+            do ig = 1, ng7
+            tau_major(ig) = speccomb *   &
+             (fac200 * absa(ind0-1,ig) + &
+              fac100 * absa(ind0,ig)   + &
+              fac000 * absa(ind0+1,ig) + &
+              fac210 * absa(ind0+8,ig) + &
+              fac110 * absa(ind0+9,ig) + &
+              fac010 * absa(ind0+10,ig))
+            end do
+#else
 !$NEC unroll(NG7)
             tau_major(1:ng7) = speccomb *   &
              (fac200 * absa(ind0-1,1:ng7) + &
@@ -286,16 +309,38 @@ INTEGER(KIND=JPIM) :: llaytrop_min, llaytrop_max
               fac210 * absa(ind0+8,1:ng7) + &
               fac110 * absa(ind0+9,1:ng7) + &
               fac010 * absa(ind0+10,1:ng7))
+#endif
           else
+#if defined(__amdflang__) && defined(OMPGPU)
+            do ig = 1, ng7
+            tau_major(ig) = speccomb *   &
+             (fac000 * absa(ind0,ig)   + &
+              fac100 * absa(ind0+1,ig) + &
+              fac010 * absa(ind0+9,ig) + &
+              fac110 * absa(ind0+10,ig))
+            end do
+#else
 !$NEC unroll(NG7)
             tau_major(1:ng7) = speccomb *   &
              (fac000 * absa(ind0,1:ng7)   + &
               fac100 * absa(ind0+1,1:ng7) + &
               fac010 * absa(ind0+9,1:ng7) + &
               fac110 * absa(ind0+10,1:ng7))
+#endif
           endif
 
           if (specparm1 .lt. 0.125_JPRB) then
+#if defined(__amdflang__) && defined(OMPGPU)
+            do ig = 1, ng7
+            tau_major1(ig) = speccomb1 *  &
+             (fac001 * absa(ind1,ig)    + &
+              fac101 * absa(ind1+1,ig)  + &
+              fac201 * absa(ind1+2,ig)  + &
+              fac011 * absa(ind1+9,ig)  + &
+              fac111 * absa(ind1+10,ig) + &
+              fac211 * absa(ind1+11,ig))
+            end do
+#else
 !$NEC unroll(NG7)
             tau_major1(1:ng7) = speccomb1 *  &
              (fac001 * absa(ind1,1:ng7)    + &
@@ -304,7 +349,19 @@ INTEGER(KIND=JPIM) :: llaytrop_min, llaytrop_max
               fac011 * absa(ind1+9,1:ng7)  + &
               fac111 * absa(ind1+10,1:ng7) + &
               fac211 * absa(ind1+11,1:ng7))
+#endif
           else if (specparm1 .gt. 0.875_JPRB) then
+#if defined(__amdflang__) && defined(OMPGPU)
+            do ig = 1, ng7
+            tau_major1(ig) = speccomb1 * &
+             (fac201 * absa(ind1-1,ig) + &
+              fac101 * absa(ind1,ig)   + &
+              fac001 * absa(ind1+1,ig) + &
+              fac211 * absa(ind1+8,ig) + &
+              fac111 * absa(ind1+9,ig) + &
+              fac011 * absa(ind1+10,ig))
+            end do
+#else
 !$NEC unroll(NG7)
             tau_major1(1:ng7) = speccomb1 * &
              (fac201 * absa(ind1-1,1:ng7) + &
@@ -313,13 +370,24 @@ INTEGER(KIND=JPIM) :: llaytrop_min, llaytrop_max
               fac211 * absa(ind1+8,1:ng7) + &
               fac111 * absa(ind1+9,1:ng7) + &
               fac011 * absa(ind1+10,1:ng7))
+#endif
           else
+#if defined(__amdflang__) && defined(OMPGPU)
+            do ig = 1, ng7
+            tau_major1(ig) = speccomb1 * &
+             (fac001 * absa(ind1,ig)   + &
+              fac101 * absa(ind1+1,ig) + &
+              fac011 * absa(ind1+9,ig) + &
+              fac111 * absa(ind1+10,ig))
+            end do
+#else
 !$NEC unroll(NG7)
             tau_major1(1:ng7) = speccomb1 * &
              (fac001 * absa(ind1,1:ng7)   + &
               fac101 * absa(ind1+1,1:ng7) + &
               fac011 * absa(ind1+9,1:ng7) + &
               fac111 * absa(ind1+10,1:ng7))
+#endif
           endif
 
           !$ACC LOOP SEQ PRIVATE(taufor, tauself, co2m1, co2m2, absco2)
@@ -542,6 +610,17 @@ INTEGER(KIND=JPIM) :: llaytrop_min, llaytrop_max
             endif
 
             if (specparm .lt. 0.125_JPRB) then
+#if defined(__amdflang__) && defined(OMPGPU)
+            do ig = 1, ng7
+              tau_major(ig) = speccomb *    &
+              (fac000 * absa(ind0,ig)    + &
+                fac100 * absa(ind0+1,ig)  + &
+                fac200 * absa(ind0+2,ig)  + &
+                fac010 * absa(ind0+9,ig)  + &
+                fac110 * absa(ind0+10,ig) + &
+                fac210 * absa(ind0+11,ig))
+            end do
+#else
 !$NEC unroll(NG7)
               tau_major(1:ng7) = speccomb *    &
               (fac000 * absa(ind0,1:ng7)    + &
@@ -550,7 +629,19 @@ INTEGER(KIND=JPIM) :: llaytrop_min, llaytrop_max
                 fac010 * absa(ind0+9,1:ng7)  + &
                 fac110 * absa(ind0+10,1:ng7) + &
                 fac210 * absa(ind0+11,1:ng7))
+#endif
             else if (specparm .gt. 0.875_JPRB) then
+#if defined(__amdflang__) && defined(OMPGPU)
+            do ig = 1, ng7
+              tau_major(ig) = speccomb *   &
+              (fac200 * absa(ind0-1,ig) + &
+                fac100 * absa(ind0,ig)   + &
+                fac000 * absa(ind0+1,ig) + &
+                fac210 * absa(ind0+8,ig) + &
+                fac110 * absa(ind0+9,ig) + &
+                fac010 * absa(ind0+10,ig))
+            end do
+#else
 !$NEC unroll(NG7)
               tau_major(1:ng7) = speccomb *   &
               (fac200 * absa(ind0-1,1:ng7) + &
@@ -559,16 +650,38 @@ INTEGER(KIND=JPIM) :: llaytrop_min, llaytrop_max
                 fac210 * absa(ind0+8,1:ng7) + &
                 fac110 * absa(ind0+9,1:ng7) + &
                 fac010 * absa(ind0+10,1:ng7))
+#endif
             else
+#if defined(__amdflang__) && defined(OMPGPU)
+            do ig = 1, ng7
+              tau_major(ig) = speccomb *   &
+              (fac000 * absa(ind0,ig)   + &
+                fac100 * absa(ind0+1,ig) + &
+                fac010 * absa(ind0+9,ig) + &
+                fac110 * absa(ind0+10,ig))
+            end do
+#else
 !$NEC unroll(NG7)
               tau_major(1:ng7) = speccomb *   &
               (fac000 * absa(ind0,1:ng7)   + &
                 fac100 * absa(ind0+1,1:ng7) + &
                 fac010 * absa(ind0+9,1:ng7) + &
                 fac110 * absa(ind0+10,1:ng7))
+#endif
             endif
 
             if (specparm1 .lt. 0.125_JPRB) then
+#if defined(__amdflang__) && defined(OMPGPU)
+            do ig = 1, ng7
+              tau_major1(ig) = speccomb1 *  &
+              (fac001 * absa(ind1,ig)    + &
+                fac101 * absa(ind1+1,ig)  + &
+                fac201 * absa(ind1+2,ig)  + &
+                fac011 * absa(ind1+9,ig)  + &
+                fac111 * absa(ind1+10,ig) + &
+                fac211 * absa(ind1+11,ig))
+            end do
+#else
 !$NEC unroll(NG7)
               tau_major1(1:ng7) = speccomb1 *  &
               (fac001 * absa(ind1,1:ng7)    + &
@@ -577,7 +690,19 @@ INTEGER(KIND=JPIM) :: llaytrop_min, llaytrop_max
                 fac011 * absa(ind1+9,1:ng7)  + &
                 fac111 * absa(ind1+10,1:ng7) + &
                 fac211 * absa(ind1+11,1:ng7))
+#endif
             else if (specparm1 .gt. 0.875_JPRB) then
+#if defined(__amdflang__) && defined(OMPGPU)
+            do ig = 1, ng7
+              tau_major1(ig) = speccomb1 * &
+              (fac201 * absa(ind1-1,ig) + &
+                fac101 * absa(ind1,ig)   + &
+                fac001 * absa(ind1+1,ig) + &
+                fac211 * absa(ind1+8,ig) + &
+                fac111 * absa(ind1+9,ig) + &
+                fac011 * absa(ind1+10,ig))
+            end do
+#else
 !$NEC unroll(NG7)
               tau_major1(1:ng7) = speccomb1 * &
               (fac201 * absa(ind1-1,1:ng7) + &
@@ -586,13 +711,24 @@ INTEGER(KIND=JPIM) :: llaytrop_min, llaytrop_max
                 fac211 * absa(ind1+8,1:ng7) + &
                 fac111 * absa(ind1+9,1:ng7) + &
                 fac011 * absa(ind1+10,1:ng7))
+#endif
             else
+#if defined(__amdflang__) && defined(OMPGPU)
+            do ig = 1, ng7
+              tau_major1(ig) = speccomb1 * &
+              (fac001 * absa(ind1,ig)   + &
+                fac101 * absa(ind1+1,ig) + &
+                fac011 * absa(ind1+9,ig) + &
+                fac111 * absa(ind1+10,ig))
+            end do
+#else
 !$NEC unroll(NG7)
               tau_major1(1:ng7) = speccomb1 * &
               (fac001 * absa(ind1,1:ng7)   + &
                 fac101 * absa(ind1+1,1:ng7) + &
                 fac011 * absa(ind1+9,1:ng7) + &
                 fac111 * absa(ind1+10,1:ng7))
+#endif
             endif
 
 !$NEC unroll(NG7)

--- a/ifsrrtm/rrtm_taumol9.F90
+++ b/ifsrrtm/rrtm_taumol9.F90
@@ -271,6 +271,17 @@ INTEGER(KIND=JPIM) :: llaytrop_min, llaytrop_max
           endif
 
           if (specparm .lt. 0.125_JPRB) then
+#if defined(__amdflang__) && defined(OMPGPU)
+            do ig = 1, ng9
+            tau_major(ig) = speccomb *    &
+             (fac000 * absa(ind0,ig)    + &
+              fac100 * absa(ind0+1,ig)  + &
+              fac200 * absa(ind0+2,ig)  + &
+              fac010 * absa(ind0+9,ig)  + &
+              fac110 * absa(ind0+10,ig) + &
+              fac210 * absa(ind0+11,ig))
+            end do
+#else
 !$NEC unroll(NG9)
             tau_major(1:ng9) = speccomb *    &
              (fac000 * absa(ind0,1:ng9)    + &
@@ -279,7 +290,19 @@ INTEGER(KIND=JPIM) :: llaytrop_min, llaytrop_max
               fac010 * absa(ind0+9,1:ng9)  + &
               fac110 * absa(ind0+10,1:ng9) + &
               fac210 * absa(ind0+11,1:ng9))
+#endif
           else if (specparm .gt. 0.875_JPRB) then
+#if defined(__amdflang__) && defined(OMPGPU)
+            do ig = 1, ng9
+            tau_major(ig) = speccomb *   &
+             (fac200 * absa(ind0-1,ig) + &
+              fac100 * absa(ind0,ig)   + &
+              fac000 * absa(ind0+1,ig) + &
+              fac210 * absa(ind0+8,ig) + &
+              fac110 * absa(ind0+9,ig) + &
+              fac010 * absa(ind0+10,ig))
+            end do
+#else
 !$NEC unroll(NG9)
             tau_major(1:ng9) = speccomb *   &
              (fac200 * absa(ind0-1,1:ng9) + &
@@ -288,16 +311,38 @@ INTEGER(KIND=JPIM) :: llaytrop_min, llaytrop_max
               fac210 * absa(ind0+8,1:ng9) + &
               fac110 * absa(ind0+9,1:ng9) + &
               fac010 * absa(ind0+10,1:ng9))
+#endif
           else
+#if defined(__amdflang__) && defined(OMPGPU)
+            do ig = 1, ng9
+            tau_major(ig) = speccomb *   &
+             (fac000 * absa(ind0,ig)   + &
+              fac100 * absa(ind0+1,ig) + &
+              fac010 * absa(ind0+9,ig) + &
+              fac110 * absa(ind0+10,ig))
+            end do
+#else
 !$NEC unroll(NG9)
             tau_major(1:ng9) = speccomb *   &
              (fac000 * absa(ind0,1:ng9)   + &
               fac100 * absa(ind0+1,1:ng9) + &
               fac010 * absa(ind0+9,1:ng9) + &
               fac110 * absa(ind0+10,1:ng9))
+#endif
           endif
 
           if (specparm1 .lt. 0.125_JPRB) then
+#if defined(__amdflang__) && defined(OMPGPU)
+            do ig = 1, ng9
+            tau_major1(ig) = speccomb1 *  &
+             (fac001 * absa(ind1,ig)    + &
+              fac101 * absa(ind1+1,ig)  + &
+              fac201 * absa(ind1+2,ig)  + &
+              fac011 * absa(ind1+9,ig)  + &
+              fac111 * absa(ind1+10,ig) + &
+              fac211 * absa(ind1+11,ig))
+            end do
+#else
 !$NEC unroll(NG9)
             tau_major1(1:ng9) = speccomb1 *  &
              (fac001 * absa(ind1,1:ng9)    + &
@@ -306,7 +351,19 @@ INTEGER(KIND=JPIM) :: llaytrop_min, llaytrop_max
               fac011 * absa(ind1+9,1:ng9)  + &
               fac111 * absa(ind1+10,1:ng9) + &
               fac211 * absa(ind1+11,1:ng9))
+#endif
           else if (specparm1 .gt. 0.875_JPRB) then
+#if defined(__amdflang__) && defined(OMPGPU)
+            do ig = 1, ng9
+            tau_major1(ig) = speccomb1 * &
+             (fac201 * absa(ind1-1,ig) + &
+              fac101 * absa(ind1,ig)   + &
+              fac001 * absa(ind1+1,ig) + &
+              fac211 * absa(ind1+8,ig) + &
+              fac111 * absa(ind1+9,ig) + &
+              fac011 * absa(ind1+10,ig))
+            end do
+#else
 !$NEC unroll(NG9)
             tau_major1(1:ng9) = speccomb1 * &
              (fac201 * absa(ind1-1,1:ng9) + &
@@ -315,13 +372,24 @@ INTEGER(KIND=JPIM) :: llaytrop_min, llaytrop_max
               fac211 * absa(ind1+8,1:ng9) + &
               fac111 * absa(ind1+9,1:ng9) + &
               fac011 * absa(ind1+10,1:ng9))
+#endif
           else
+#if defined(__amdflang__) && defined(OMPGPU)
+            do ig = 1, ng9
+            tau_major1(ig) = speccomb1 * &
+             (fac001 * absa(ind1,ig)   + &
+              fac101 * absa(ind1+1,ig) + &
+              fac011 * absa(ind1+9,ig) + &
+              fac111 * absa(ind1+10,ig))
+            end do
+#else
 !$NEC unroll(NG9)
             tau_major1(1:ng9) = speccomb1 * &
              (fac001 * absa(ind1,1:ng9)   + &
               fac101 * absa(ind1+1,1:ng9) + &
               fac011 * absa(ind1+9,1:ng9) + &
               fac111 * absa(ind1+10,1:ng9))
+#endif
           endif
 
           !$ACC LOOP SEQ PRIVATE(taufor, tauself, n2om1, n2om2, absn2o)
@@ -525,6 +593,17 @@ INTEGER(KIND=JPIM) :: llaytrop_min, llaytrop_max
             endif
 
             if (specparm .lt. 0.125_JPRB) then
+#if defined(__amdflang__) && defined(OMPGPU)
+            do ig = 1, ng9
+              tau_major(ig) = speccomb *    &
+              (fac000 * absa(ind0,ig)    + &
+                fac100 * absa(ind0+1,ig)  + &
+                fac200 * absa(ind0+2,ig)  + &
+                fac010 * absa(ind0+9,ig)  + &
+                fac110 * absa(ind0+10,ig) + &
+                fac210 * absa(ind0+11,ig))
+            end do
+#else
 !$NEC unroll(NG9)
               tau_major(1:ng9) = speccomb *    &
               (fac000 * absa(ind0,1:ng9)    + &
@@ -533,7 +612,19 @@ INTEGER(KIND=JPIM) :: llaytrop_min, llaytrop_max
                 fac010 * absa(ind0+9,1:ng9)  + &
                 fac110 * absa(ind0+10,1:ng9) + &
                 fac210 * absa(ind0+11,1:ng9))
+#endif
             else if (specparm .gt. 0.875_JPRB) then
+#if defined(__amdflang__) && defined(OMPGPU)
+            do ig = 1, ng9
+              tau_major(ig) = speccomb *   &
+              (fac200 * absa(ind0-1,ig) + &
+                fac100 * absa(ind0,ig)   + &
+                fac000 * absa(ind0+1,ig) + &
+                fac210 * absa(ind0+8,ig) + &
+                fac110 * absa(ind0+9,ig) + &
+                fac010 * absa(ind0+10,ig))
+            end do
+#else
 !$NEC unroll(NG9)
               tau_major(1:ng9) = speccomb *   &
               (fac200 * absa(ind0-1,1:ng9) + &
@@ -542,16 +633,38 @@ INTEGER(KIND=JPIM) :: llaytrop_min, llaytrop_max
                 fac210 * absa(ind0+8,1:ng9) + &
                 fac110 * absa(ind0+9,1:ng9) + &
                 fac010 * absa(ind0+10,1:ng9))
+#endif
             else
+#if defined(__amdflang__) && defined(OMPGPU)
+            do ig = 1, ng9
+              tau_major(ig) = speccomb *   &
+              (fac000 * absa(ind0,ig)   + &
+                fac100 * absa(ind0+1,ig) + &
+                fac010 * absa(ind0+9,ig) + &
+                fac110 * absa(ind0+10,ig))
+            end do
+#else
 !$NEC unroll(NG9)
               tau_major(1:ng9) = speccomb *   &
               (fac000 * absa(ind0,1:ng9)   + &
                 fac100 * absa(ind0+1,1:ng9) + &
                 fac010 * absa(ind0+9,1:ng9) + &
                 fac110 * absa(ind0+10,1:ng9))
+#endif
             endif
 
             if (specparm1 .lt. 0.125_JPRB) then
+#if defined(__amdflang__) && defined(OMPGPU)
+            do ig = 1, ng9
+              tau_major1(ig) = speccomb1 *  &
+              (fac001 * absa(ind1,ig)    + &
+                fac101 * absa(ind1+1,ig)  + &
+                fac201 * absa(ind1+2,ig)  + &
+                fac011 * absa(ind1+9,ig)  + &
+                fac111 * absa(ind1+10,ig) + &
+                fac211 * absa(ind1+11,ig))
+            end do
+#else
 !$NEC unroll(NG9)
               tau_major1(1:ng9) = speccomb1 *  &
               (fac001 * absa(ind1,1:ng9)    + &
@@ -560,7 +673,19 @@ INTEGER(KIND=JPIM) :: llaytrop_min, llaytrop_max
                 fac011 * absa(ind1+9,1:ng9)  + &
                 fac111 * absa(ind1+10,1:ng9) + &
                 fac211 * absa(ind1+11,1:ng9))
+#endif
             else if (specparm1 .gt. 0.875_JPRB) then
+#if defined(__amdflang__) && defined(OMPGPU)
+            do ig = 1, ng9
+              tau_major1(ig) = speccomb1 * &
+              (fac201 * absa(ind1-1,ig) + &
+                fac101 * absa(ind1,ig)   + &
+                fac001 * absa(ind1+1,ig) + &
+                fac211 * absa(ind1+8,ig) + &
+                fac111 * absa(ind1+9,ig) + &
+                fac011 * absa(ind1+10,ig))
+            end do
+#else
 !$NEC unroll(NG9)
               tau_major1(1:ng9) = speccomb1 * &
               (fac201 * absa(ind1-1,1:ng9) + &
@@ -569,13 +694,24 @@ INTEGER(KIND=JPIM) :: llaytrop_min, llaytrop_max
                 fac211 * absa(ind1+8,1:ng9) + &
                 fac111 * absa(ind1+9,1:ng9) + &
                 fac011 * absa(ind1+10,1:ng9))
+#endif
             else
+#if defined(__amdflang__) && defined(OMPGPU)
+            do ig = 1, ng9
+              tau_major1(ig) = speccomb1 * &
+              (fac001 * absa(ind1,ig)   + &
+                fac101 * absa(ind1+1,ig) + &
+                fac011 * absa(ind1+9,ig) + &
+                fac111 * absa(ind1+10,ig))
+            end do
+#else
 !$NEC unroll(NG9)
               tau_major1(1:ng9) = speccomb1 * &
               (fac001 * absa(ind1,1:ng9)   + &
                 fac101 * absa(ind1+1,1:ng9) + &
                 fac011 * absa(ind1+9,1:ng9) + &
                 fac111 * absa(ind1+10,1:ng9))
+#endif
             endif
 
 !$NEC unroll(NG9)


### PR DESCRIPTION
In this branch, we provide a workaround that affects both the performance and correctness of array computations in rrtm_taumol modules. This likely only affects amdflang with OpenMP Offload.