### PR TITLE
Flotsam intel support for DISORT plus repository housekeeping

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,5 +8,3 @@ config_*.nam
 
 bin/*
 mod
-practical/data
-practical/ecrad

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,9 @@
 *_out.nc
 config_*.nam
 *_sza.nc
+*.log
+
+bin/*
+mod
+practical/data
+practical/ecrad

--- a/Makefile
+++ b/Makefile
@@ -131,9 +131,6 @@ deps: clean-deps
 clean-deps:
 	rm -f include/*.intfb.h
 
-clean-mod:
-	rm -rf mod
-
 libifs: libradiation
 	cd ifs && $(MAKE)
 
@@ -185,7 +182,7 @@ test_ckdmip:
 test_disort:
 	cd test/disort && $(MAKE) test
 
-clean: clean-tests clean-toplevel clean-utilities clean-mod clean-symlinks
+clean: clean-tests clean-toplevel clean-utilities clean-mods clean-symlinks
 
 clean-tests:
 	cd test/ifs && $(MAKE) clean

--- a/Makefile
+++ b/Makefile
@@ -131,6 +131,9 @@ deps: clean-deps
 clean-deps:
 	rm -f include/*.intfb.h
 
+clean-mod:
+	rm -rf mod
+
 libifs: libradiation
 	cd ifs && $(MAKE)
 
@@ -182,7 +185,7 @@ test_ckdmip:
 test_disort:
 	cd test/disort && $(MAKE) test
 
-clean: clean-tests clean-toplevel clean-utilities clean-mods clean-symlinks
+clean: clean-tests clean-toplevel clean-utilities clean-mod clean-symlinks
 
 clean-tests:
 	cd test/ifs && $(MAKE) clean

--- a/disort/Makefile
+++ b/disort/Makefile
@@ -8,8 +8,15 @@ ifdef SINGLE_PRECISION
   # DISORT takes single-precision arguments by default	
   LOCALFLAGS = 
 else
-  # gfortran-specific flags to use double precision
-  LOCALFLAGS = -fdefault-real-8 -fdefault-double-8
+	# Build DISORT in double precision to match callers using jprb.
+	# Use compiler-specific flags.
+	ifeq ($(findstring ifort,$(FC)),ifort)
+		LOCALFLAGS = -real-size 64
+	else ifeq ($(findstring ifx,$(FC)),ifx)
+		LOCALFLAGS = -real-size 64
+	else
+		LOCALFLAGS = -fdefault-real-8 -fdefault-double-8
+	endif
 endif
 
 all: $(LIBDISORT)

--- a/practical/.gitignore
+++ b/practical/.gitignore
@@ -1,0 +1,2 @@
+data
+ecrad


### PR DESCRIPTION
### Description
At the moment ecRad FLOTSAM needs to be built in double precision due to the interface in disort/cgqf.F90 for the quadrature, which hardcodes reals of kind(8). This merge simply adds the corresponding real-size 64 (https://www.intel.com/content/www/us/en/docs/fortran-compiler/developer-guide-reference/2025-2/real-size.html) mirroring the behaviour for the gfortran compiler.

Plus some extra housekeeping rules for the repository are added in .gitignore and a clean-mod rule is added into the root Makefile so that builds do not interfere with git checks.

### Contributor Declaration

By opening this pull request, I affirm the following:

* All authors agree to the [Contributor License Agreement](https://github.com/ecmwf/codex/blob/main/Legal/contributor_license_agreement.md).
* The code follows the project's coding standards.
* I have performed self-review and added comments where needed.
* I have added or updated tests to verify that my changes are effective and functional.
* I have run all existing tests and confirmed they pass.
 