### PR TITLE
Migrate PR automation to prtk check

### DIFF
--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -1,17 +1,24 @@
 name: check-pr
 
+concurrency:
+  group: prtk-pr-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
 on:
   pull_request_target:
-    types: [opened, synchronize, reopened]
+    types: [opened, synchronize, reopened, edited, ready_for_review, converted_to_draft]
     branches: [ master, develop ]
 
 permissions:
   contents: read
   pull-requests: write
+  issues: write
 
 jobs:
   check-pr:
+    if: github.repository_owner == 'ecmwf-ifs'
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     steps:
 
       - name: Checkout code
@@ -27,12 +34,16 @@ jobs:
 
       - name: Install prtk
         env:
-            PRTK_READ_ACCESS_TOKEN: ${{ secrets.PRTK_READ_ACCESS }}
+          PRTK_READ_ACCESS_TOKEN: ${{ secrets.PRTK_READ_ACCESS }}
         run: |
           uv tool install "git+https://${PRTK_READ_ACCESS_TOKEN}@github.com/ecmwf-ifs/prtk"
 
-      - name: Assign reviewers
+      - name: Run prtk checks
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          prtk assign-reviewers --pr-number ${{ github.event.pull_request.number }}
+        run: >-
+          prtk check
+          --pr-number "${{ github.event.pull_request.number }}"
+          --default-branch "${{ github.event.repository.default_branch }}"
+          --event-name "${{ github.event_name }}"
+          --event-action "${{ github.event.action }}"

--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -6,3 +6,20 @@ maintainers:
 lead_developers:
   - rjhogan
 
+checks:
+  ensure-assignee: {}
+  validate-target-branch:
+    allowed-branches:
+      - master
+      - develop
+  assign-reviewers:
+    exclude-author: true
+    exclude-existing: true
+  copyright-audit:
+    reviewer: msleigh
+    skip-label: "prtk:skip-copyright"
+    allowed-holders:
+      - ECMWF
+      - European Centre for Medium-Range Weather Forecasts
+      - Meteo-France
+      - Meteo France


### PR DESCRIPTION
## Summary

Migrates ecrad's PR automation from the standalone `prtk assign-reviewers` command to the current `prtk check` entry point, and adds a `checks:` section to `MAINTAINERS.yml`. No Jira and no `cycle_leads` (this repo doesn't use them).

### `MAINTAINERS.yml`

- `ensure-assignee` — every non-draft PR gets one assignee (falls back to `reuterbal`, the top-level maintainer)
- `validate-target-branch` — PRs must target `master` or `develop`. PRs against feature branches will be rejected with a clear message
- `assign-reviewers` — path-based reviewer requesting, with `exclude-author` and `exclude-existing`
- `copyright-audit` — advisory comment for suspicious copyright additions, with `allowed-holders` covering ECMWF and Météo-France variants. Skippable per-PR with the `prtk:skip-copyright` label

### `.github/workflows/pr-check.yml`

- Replaces the single `prtk assign-reviewers ...` step with `prtk check ...`, passing `--default-branch` and the GitHub event metadata that the new entry point expects
- Expands `pull_request_target` event types to `opened, synchronize, reopened, edited, ready_for_review, converted_to_draft` so `prtk check` can react to title edits, draft transitions, etc.
- Adds `issues: write` permission (needed by `ensure-assignee`)
- Adds a concurrency group so rapid PR updates cancel in-flight runs
- Adds `timeout-minutes: 5`

### Out of scope

- No scheduled `prtk scan` / `close-stale` workflow. Can be a follow-up if stale-PR cleanup is wanted.

## Test plan

- [x] Open a draft PR against `master` and confirm the `prtk` job skips automation (draft handling)
- [x] Mark the PR ready for review and confirm: one assignee is set, reviewers are requested per `MAINTAINERS.yml` rules
- [x] Open a test PR against a non-allowed base branch and confirm `validate-target-branch` fails with a clear message
- [x] Edit a PR title and confirm `prtk check` re-runs on the `edited` event
