### PR TITLE
README: Remove outdated CLA link

### DIFF
--- a/README.md
+++ b/README.md
@@ -246,7 +246,7 @@ the gas optics part of the Rapid Radiative Transfer Model for GCMS
 
 # Contributing
 
-Contributions to ECRAD are welcome under the [contributor license agreement (CLA)](https://github.com/ecmwf/codex/blob/main/Legal/contributor_license_agreement.md).
+Contributions to ECRAD are welcome.
 In order to do so, please open an issue where a feature request or bug can be discussed.
 Then create a pull request with your contribution.
 


### PR DESCRIPTION
CLA is automatically being linked via PR template.

### Description


### Contributor Declaration

By opening this pull request, I affirm the following:

* All authors agree to the [Contributor License Agreement](https://github.com/ecmwf/codex/blob/main/Legal/contributor_license_agreement.md).
* The code follows the project's coding standards.
* I have performed self-review and added comments where needed.
* I have added or updated tests to verify that my changes are effective and functional.
* I have run all existing tests and confirmed they pass.
 