### PR TITLE
(master-omp) PR 1: Correctness, Performance, and Instrumentation

### DIFF
--- a/driver/ecrad_ifs_driver_blocked.F90
+++ b/driver/ecrad_ifs_driver_blocked.F90
@@ -69,6 +69,7 @@ program ecrad_ifs_driver
   use ecrad_driver_read_input,  only : read_input
   use easy_netcdf
   use ifs_blocking
+  use iso_fortran_env,          only : int64
 #ifdef HAVE_NVTX
   use nvtx
 #endif
@@ -142,6 +143,9 @@ program ecrad_ifs_driver
   ! Loop index for repeats (for benchmarking)
   integer :: jrepeat
 
+  integer(kind=int64) :: count_rate, t(4)
+  real(kind=jprd) :: total_dt, kernel_dt
+
   ! Loop index
   integer :: jrl, ibeg, iend, il, ib
 
@@ -167,6 +171,7 @@ program ecrad_ifs_driver
 #endif
 
   call dr_hook_init()
+  call system_clock(count_rate=count_rate)
 
   ! --------------------------------------------------------
   ! Section 2: Configure
@@ -401,6 +406,9 @@ program ecrad_ifs_driver
   ! Option of repeating calculation multiple time for more accurate
   ! profiling
   do jrepeat = 1,driver_config%nrepeat
+     total_dt = 0.0_jprd
+     kernel_dt = 0.0_jprd
+
 #ifdef HAVE_NVTX
      call nvtxStartRange("ecrad_it")
 #endif
@@ -435,10 +443,11 @@ program ecrad_ifs_driver
       ! Run radiation scheme over blocks of columns in parallel
 
 #ifndef OMPGPU
-      !$OMP PARALLEL DO SCHEDULE(DYNAMIC,1)&
-      !$OMP&PRIVATE(JRL,IBEG,IEND,IL,IB)
+      !$OMP PARALLEL DO SCHEDULE(DYNAMIC,1) REDUCTION(+:total_dt,kernel_dt)&
+      !$OMP&PRIVATE(JRL,IBEG,IEND,IL,IB,t)
 #endif
       do jrl=1,ncol,nproma
+        call system_clock(count=t(1))
         ibeg=jrl
         iend=min(ibeg+nproma-1,ncol)
         il=iend-ibeg+1
@@ -496,6 +505,8 @@ program ecrad_ifs_driver
 #endif
 #endif /* COPY_ASYNC */
 
+        call system_clock(count=t(3))
+
         ! Call the ECRAD radiation scheme
         call radiation_scheme &
              & (yradiation, &
@@ -541,6 +552,8 @@ program ecrad_ifs_driver
 #endif
              & )
 
+        call system_clock(count=t(4))
+
 #if defined(OMPGPU)
 #ifdef COPY_ASYNC
 #else
@@ -557,6 +570,9 @@ program ecrad_ifs_driver
           !$acc end data
 #endif
 #endif
+        call system_clock(count=t(2))
+        total_dt = total_dt + (t(2)-t(1))/dble(count_rate)
+        kernel_dt = kernel_dt + (t(4)-t(3))/dble(count_rate)
       end do
 #ifndef OMPGPU
       !$OMP END PARALLEL DO
@@ -579,22 +595,19 @@ program ecrad_ifs_driver
      call roctxEndRange
 #endif
 
+     write(nulout, '(a,g12.5,a)') 'time elapsed in radiative transfer: ', &
+          &                         total_dt, ' seconds'
+     write(nulout, '(a,g12.5,a)') 'time elapsed in radiative transfer kernel: ', &
+          &                         kernel_dt, ' seconds'
+     write(nulout, '(a,i0)') 'Columns/s : ', int((ncol)/total_dt)
+     write(nulout, '(a,i0)') 'Columns/s : ', int((ncol)/kernel_dt)
+
   end do
 
 #if defined(OMPGPU)
 #endif
 #if defined(_OPENACC)
 !$acc wait
-#endif
-
-#ifndef NO_OPENMP
-  if (driver_config%nrepeat > driver_config%nwarmup) then
-    tstop = omp_get_wtime()
-    write(nulout, '(a,g12.5,a)') 'Total time elapsed in radiative transfer: ', tstop-tstart, ' seconds'
-    write(nulout, '(a,g12.5,a)') 'Average time elapsed in radiative transfer: ', &
-      &                         (tstop-tstart)/(driver_config%nrepeat-driver_config%nwarmup), ' seconds'
-    write(nulout, '(a,i0)') 'Columns/s : ', int((ncol*(driver_config%nrepeat-driver_config%nwarmup))/(tstop-tstart))
-  end if
 #endif
 
   ! --------------------------------------------------------

--- a/driver/ecrad_ifs_driver_blocked.F90
+++ b/driver/ecrad_ifs_driver_blocked.F90
@@ -484,13 +484,19 @@ program ecrad_ifs_driver
 
 #else  /* COPY_ASYNC */
 
+        ! Pad unused column rows with zero on host so full nproma-sized
+        ! OMPGPU transfers are safe when il < nproma (partial last block).
 #if defined(OMPGPU)
+        if (il < nproma) then
+          zrgp(il+1:nproma, ifs_config%iinbeg:ifs_config%iinend, ib) = 0._jprb
+          zrgp(il+1:nproma, ifs_config%ioutend+1:ifs_config%ifldstot, ib) = 0._jprb
+        endif
         !$OMP TARGET ENTER DATA MAP(ALLOC:zrgp(:,:,ib))
 #ifdef BITIDENTITY_TESTING
         !$OMP TARGET UPDATE TO(iseed(:,ib))
 #endif
-        !$OMP TARGET UPDATE TO(zrgp(1:il,ifs_config%iinbeg:ifs_config%iinend,ib), &
-        !$OMP&                 zrgp(1:il,ifs_config%ioutend+1:ifs_config%ifldstot,ib))
+        !$OMP TARGET UPDATE TO(zrgp(:,ifs_config%iinbeg:ifs_config%iinend,ib), &
+        !$OMP&                 zrgp(:,ifs_config%ioutend+1:ifs_config%ifldstot,ib))
 #endif
 #if defined(_OPENACC)
         !$acc data create(zrgp(:,:,ib)) &
@@ -557,7 +563,10 @@ program ecrad_ifs_driver
 #if defined(OMPGPU)
 #ifdef COPY_ASYNC
 #else
-        !$OMP TARGET UPDATE FROM(zrgp(1:il,ifs_config%ioutbeg:ifs_config%ioutend,ib))
+        ! Flang omptarget mishandles partial row slices (1:il,:); use the
+        ! same full nproma output-field transfer as full blocks. Only
+        ! rows 1:il are read when scattering fluxes back to global arrays.
+        !$OMP TARGET UPDATE FROM(zrgp(:,ifs_config%ioutbeg:ifs_config%ioutend,ib))
         !$OMP TARGET EXIT DATA MAP(DELETE:zrgp(:,:,ib))
 #endif
 #endif

--- a/radiation/radiation_lw_derivatives.F90
+++ b/radiation/radiation_lw_derivatives.F90
@@ -36,9 +36,6 @@ module radiation_lw_derivatives
 
   implicit none
 
-  !$omp declare target(calc_lw_derivatives_ica_omp)
-  !$omp declare target(modify_lw_derivatives_ica_omp)
-
   public
 
 contains
@@ -188,110 +185,6 @@ contains
 #endif
 
   end subroutine modify_lw_derivatives_ica
-
-  !---------------------------------------------------------------------
-  ! Calculation for the Independent Column Approximation
-  ! uses global memory to for writing out the results of the reduction
-  subroutine calc_lw_derivatives_ica_omp(ng, nlev, icol, transmittance, flux_up_surf, lw_derivatives, lw_derivatives_g)
-
-    use parkind1, only           : jprb
-    implicit none
-
-    ! Inputs
-    integer,    intent(in) :: ng   ! number of spectral intervals
-    integer,    intent(in) :: nlev ! number of levels
-    integer,    intent(in) :: icol ! Index of column for output
-    real(jprb), intent(in) :: transmittance(ng,nlev)
-    real(jprb), intent(in) :: flux_up_surf(ng) ! Upwelling surface spectral flux (W m-2)
-
-    ! Output
-    real(jprb), intent(out) :: lw_derivatives(:,:) ! dimensioned (ncol,nlev+1)
-
-    ! Rate of change of spectral flux at a given height with respect
-    ! to the surface value
-    real(jprb), intent(inout) :: lw_derivatives_g(ng)
-
-    real(jprb) :: sum_flux_up_surf, sum_lw_derivatives_g
-
-    integer    :: jlev, jg
-
-    sum_flux_up_surf = 0.0_jprb
-    do jg = 1,ng
-       sum_flux_up_surf = sum_flux_up_surf + flux_up_surf(jg)
-    end do
-    ! Initialize the derivatives at the surface
-    do jg = 1,ng
-      lw_derivatives_g(jg) = flux_up_surf(jg) / sum_flux_up_surf
-    end do
-    lw_derivatives(icol, nlev+1) = 1.0_jprb
-
-    ! Move up through the atmosphere computing the derivatives at each
-    ! half-level
-    do jlev = nlev,1,-1
-      sum_lw_derivatives_g = 0.0_jprb
-      do jg = 1,ng
-        lw_derivatives_g(jg) = lw_derivatives_g(jg) * transmittance(jg,jlev)
-        sum_lw_derivatives_g = sum_lw_derivatives_g + lw_derivatives_g(jg)
-      end do
-      lw_derivatives(icol,jlev) = sum_lw_derivatives_g
-    end do
-
-  end subroutine calc_lw_derivatives_ica_omp
-
-  !---------------------------------------------------------------------
-  ! Calculation for the Independent Column Approximation
-  ! uses global memory to for writing out the results of the reduction
-  subroutine modify_lw_derivatives_ica_omp(ng, nlev, icol, transmittance, flux_up_surf, &
-       &                                   weight, lw_derivatives, lw_derivatives_g)
-
-    use parkind1, only           : jprb
-
-    implicit none
-
-    ! Inputs
-    integer,    intent(in) :: ng   ! number of spectral intervals
-    integer,    intent(in) :: nlev ! number of levels
-    integer,    intent(in) :: icol ! Index of column for output
-    real(jprb), intent(in) :: transmittance(ng,nlev)
-    real(jprb), intent(in) :: flux_up_surf(ng) ! Upwelling surface spectral flux (W m-2)
-    real(jprb), intent(in) :: weight ! Weight new values against existing
-
-    ! Output
-    real(jprb), intent(inout) :: lw_derivatives(:,:) ! dimensioned (ncol,nlev+1)
-
-    ! Rate of change of spectral flux at a given height with respect
-    ! to the surface value
-    real(jprb), intent(inout) :: lw_derivatives_g(ng)
-
-    real(jprb) :: sum_flux_up_surf, sum_lw_derivatives_g
-
-    integer    :: jlev, jg
-
-    sum_flux_up_surf = 0.0_jprb
-    do jg = 1,ng
-      sum_flux_up_surf = sum_flux_up_surf + flux_up_surf(jg)
-    end do
-    ! Initialize the derivatives at the surface
-    do jg = 1,ng
-      lw_derivatives_g(jg) = flux_up_surf(jg) / sum_flux_up_surf
-    end do
-
-    ! This value must be 1 so no weighting applied
-    lw_derivatives(icol, nlev+1) = 1.0_jprb
-
-    ! Move up through the atmosphere computing the derivatives at each
-    ! half-level
-    do jlev = nlev,1,-1
-      sum_lw_derivatives_g = 0.0_jprb
-      do jg = 1,ng
-        lw_derivatives_g(jg) = lw_derivatives_g(jg) * transmittance(jg,jlev)
-        sum_lw_derivatives_g = sum_lw_derivatives_g + lw_derivatives_g(jg)
-      end do
-      lw_derivatives(icol,jlev) = (1.0_jprb - weight) * lw_derivatives(icol,jlev) &
-           &                    + weight * sum_lw_derivatives_g
-    end do
-
-  end subroutine modify_lw_derivatives_ica_omp
 
   !---------------------------------------------------------------------
   ! Calculation for solvers involving multiple regions and matrices

--- a/radiation/radiation_mcica_omp_lw.F90
+++ b/radiation/radiation_mcica_omp_lw.F90
@@ -57,7 +57,6 @@ contains
          &                               calc_no_scattering_transmittance_lw_single_cell_omp
     use radiation_adding_ica_lw, only  : fast_adding_ica_lw_omp, calc_fluxes_no_scattering_lw_omp
     
-    use radiation_lw_derivatives, only : calc_lw_derivatives_ica_omp, modify_lw_derivatives_ica_omp
     use radiation_cloud_generator_acc, only: cloud_generator_omp
     use radiation_cloud_cover, only    : beta2alpha, MaxCloudFrac
 
@@ -167,7 +166,6 @@ contains
          &                               calc_no_scattering_transmittance_lw_omp, &
          &                               calc_no_scattering_transmittance_lw_single_cell_omp
     use radiation_adding_ica_lw, only  : fast_adding_ica_lw_omp, calc_fluxes_no_scattering_lw_omp
-    use radiation_lw_derivatives, only : calc_lw_derivatives_ica_omp, modify_lw_derivatives_ica_omp
     use radiation_cloud_generator_acc, only: cloud_generator_omp
     use radiation_cloud_cover, only    : beta2alpha, MaxCloudFrac
 
@@ -247,7 +245,6 @@ contains
     
         ! Temporary working array
     real(jprb), dimension(ng,nlev+1, istartcol:iendcol) :: tmp_work_source
-    real(jprb), dimension(ng, istartcol:iendcol) :: tmp_derivatives
 
     !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
     ! Local variables : Stack
@@ -303,8 +300,7 @@ contains
     !
 
     !$OMP TARGET ENTER DATA MAP(ALLOC: trans_clear, od_scaling, &
-    !$OMP   reflectance, transmittance, source_up, source_dn, tmp_work_source, &
-    !$OMP   tmp_derivatives)
+    !$OMP   reflectance, transmittance, source_up, source_dn, tmp_work_source)
 
     !$OMP TARGET TEAMS DISTRIBUTE PARALLEL DO COLLAPSE(2)
     do jlev = 1,nfsd
@@ -704,8 +700,7 @@ contains
     !$OMP END TARGET TEAMS DISTRIBUTE PARALLEL DO
 
     !$OMP TARGET EXIT DATA MAP(DELETE: trans_clear, od_scaling, &
-    !$OMP   reflectance, transmittance, source_up, source_dn, tmp_work_source, &
-    !$OMP   tmp_derivatives)
+    !$OMP   reflectance, transmittance, source_up, source_dn, tmp_work_source)
 
     !$OMP TARGET EXIT DATA MAP(DELETE: flux_up, flux_dn, flux_up_clear, flux_dn_clear, &
     !$OMP             is_clear_sky_layer, &

--- a/radiation/radiation_mcica_omp_lw.F90
+++ b/radiation/radiation_mcica_omp_lw.F90
@@ -24,6 +24,7 @@ module radiation_mcica_omp_lw
 
   use radiation_io, only : nulout
   public
+  private :: solver_mcica_omp_lw_impl
 
 contains
 
@@ -99,19 +100,120 @@ contains
     ! Output
     type(flux_type), intent(inout):: flux
 
+    real(jphook) :: hook_handle
+
+#ifdef HAVE_ROCTX
+    call roctxStartRange("radiation::mcica_omp_lw"//c_null_char)
+#endif
+
+    if (lhook) call dr_hook('radiation_mcica_omp_lw:solver_mcica_omp_lw',0,hook_handle)
+
+    if (.not. config%do_clear) then
+      write(nulerr,'(a)') '*** Error: longwave McICA OMP requires clear-sky calculation to be performed'
+      call radiation_abort()
+    end if
+
+    if (config%do_lw_derivatives) then
+      call solver_mcica_omp_lw_impl(nlev, size(cloud%fraction,1), istartcol, iendcol, config%n_g_lw, &
+           & config%pdf_sampler%ncdf, config%pdf_sampler%nfsd, &
+           & config%n_g_lw_if_scattering, config%n_bands_lw, config%n_bands_lw_if_scattering, &
+           & config%use_beta_overlap, &
+           & config%do_lw_cloud_scattering, config%do_lw_derivatives, &
+           & config%cloud_fraction_threshold, config%cloud_inhom_decorr_scaling, &
+           & config%pdf_sampler%fsd1, config%pdf_sampler%inv_fsd_interval, &
+           & config%i_band_from_reordered_g_lw, config%pdf_sampler%val, single_level%iseed, &
+           & cloud%fraction, cloud%fractional_std, cloud%overlap_param, &
+           & od, ssa, g, od_cloud, ssa_cloud, g_cloud, planck_hl, emission, albedo, &
+           & flux%cloud_cover_lw, flux%lw_dn_surf_clear_g, flux%lw_dn_surf_g, &
+           & flux%lw_up_clear, flux%lw_dn_clear, flux%lw_up, flux%lw_dn, flux%lw_derivatives)
+    else
+      call solver_mcica_omp_lw_impl(nlev, size(cloud%fraction,1), istartcol, iendcol, config%n_g_lw, &
+           & config%pdf_sampler%ncdf, config%pdf_sampler%nfsd, &
+           & config%n_g_lw_if_scattering, config%n_bands_lw, config%n_bands_lw_if_scattering, &
+           & config%use_beta_overlap, &
+           & config%do_lw_cloud_scattering, config%do_lw_derivatives, &
+           & config%cloud_fraction_threshold, config%cloud_inhom_decorr_scaling, &
+           & config%pdf_sampler%fsd1, config%pdf_sampler%inv_fsd_interval, &
+           & config%i_band_from_reordered_g_lw, config%pdf_sampler%val, single_level%iseed, &
+           & cloud%fraction, cloud%fractional_std, cloud%overlap_param, &
+           & od, ssa, g, od_cloud, ssa_cloud, g_cloud, planck_hl, emission, albedo, &
+           & flux%cloud_cover_lw, flux%lw_dn_surf_clear_g, flux%lw_dn_surf_g, &
+           & flux%lw_up_clear, flux%lw_dn_clear, flux%lw_up, flux%lw_dn)
+    end if
+
+#ifdef HAVE_ROCTX
+    call roctxEndRange
+#endif
+    if (lhook) call dr_hook('radiation_mcica_omp_lw:solver_mcica_omp_lw',1,hook_handle)
+
+  end subroutine solver_mcica_omp_lw
+
+  !---------------------------------------------------------------------
+  ! Implementation taking only intrinsic scalars and explicit-shape
+  ! arrays.  Explicit shape matters: an assumed-shape dummy still carries
+  ! a Fortran descriptor that the runtime remaps at every target region,
+  ! whereas an explicit-shape dummy is just a base address.
+  subroutine solver_mcica_omp_lw_impl(nlev, ncol, istartcol, iendcol, ng, ncdf, nfsd, &
+       & ng_if_scattering, n_bands, n_bands_if_scattering, &
+       & use_beta_overlap, do_lw_cloud_scattering, do_lw_derivatives, &
+       & cloud_fraction_threshold, cloud_inhom_decorr_scaling, fsd1, inv_fsd_interval, &
+       & i_band_from_reordered_g_lw, pdf_val, iseed, cloud_fraction, cloud_fractional_std, &
+       & cloud_overlap_param, od, ssa, g, od_cloud, ssa_cloud, g_cloud, planck_hl, &
+       & emission, albedo, cloud_cover_lw, lw_dn_surf_clear_g, lw_dn_surf_g, &
+       & lw_up_clear, lw_dn_clear, lw_up, lw_dn, lw_derivatives)
+
+    use parkind1, only           : jprb
+    use radiation_two_stream, only     : calc_ref_trans_lw_single_level_omp, &
+         &                               calc_no_scattering_transmittance_lw_omp, &
+         &                               calc_no_scattering_transmittance_lw_single_cell_omp
+    use radiation_adding_ica_lw, only  : fast_adding_ica_lw_omp, calc_fluxes_no_scattering_lw_omp
+    use radiation_lw_derivatives, only : calc_lw_derivatives_ica_omp, modify_lw_derivatives_ica_omp
+    use radiation_cloud_generator_acc, only: cloud_generator_omp
+    use radiation_cloud_cover, only    : beta2alpha, MaxCloudFrac
+
+    implicit none
+
+    integer, intent(in) :: nlev, ncol, istartcol, iendcol, ng, ncdf, nfsd
+    integer, intent(in) :: ng_if_scattering, n_bands, n_bands_if_scattering
+    logical, intent(in) :: use_beta_overlap, do_lw_cloud_scattering, do_lw_derivatives
+    real(jprb), intent(in) :: cloud_fraction_threshold, cloud_inhom_decorr_scaling
+    real(jprb), intent(in) :: fsd1, inv_fsd_interval
+    integer, intent(in) :: i_band_from_reordered_g_lw(ng)
+    real(jprb), intent(in) :: pdf_val(ncdf,nfsd)
+    integer, intent(in) :: iseed(ncol)
+    real(jprb), intent(in) :: cloud_fraction(ncol,nlev)
+    real(jprb), intent(in) :: cloud_fractional_std(ncol,nlev)
+    real(jprb), intent(in) :: cloud_overlap_param(ncol,nlev-1)
+    real(jprb), intent(in) :: od(ng,nlev,istartcol:iendcol)
+    real(jprb), intent(in) :: ssa(ng_if_scattering,nlev,istartcol:iendcol)
+    real(jprb), intent(in) :: g(ng_if_scattering,nlev,istartcol:iendcol)
+    real(jprb), intent(in) :: od_cloud(n_bands,nlev,istartcol:iendcol)
+    real(jprb), intent(in) :: ssa_cloud(n_bands_if_scattering,nlev,istartcol:iendcol)
+    real(jprb), intent(in) :: g_cloud(n_bands_if_scattering,nlev,istartcol:iendcol)
+    real(jprb), intent(in) :: planck_hl(ng,nlev+1,istartcol:iendcol)
+    real(jprb), intent(in) :: emission(ng,istartcol:iendcol), albedo(ng,istartcol:iendcol)
+    real(jprb), intent(inout) :: cloud_cover_lw(ncol)
+    real(jprb), intent(inout) :: lw_dn_surf_clear_g(ng,ncol)
+    real(jprb), intent(inout) :: lw_dn_surf_g(ng,ncol)
+    real(jprb), intent(inout) :: lw_up_clear(ncol,nlev+1)
+    real(jprb), intent(inout) :: lw_dn_clear(ncol,nlev+1)
+    real(jprb), intent(inout) :: lw_up(ncol,nlev+1)
+    real(jprb), intent(inout) :: lw_dn(ncol,nlev+1)
+    real(jprb), intent(inout), optional :: lw_derivatives(ncol,nlev+1)
+
     !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
     ! Local variables : Mapped into Global Memory
     !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
     
     ! Fluxes per g point
-    real(jprb), dimension(config%n_g_lw, nlev+1, istartcol:iendcol) :: flux_up, flux_dn
-    real(jprb), dimension(config%n_g_lw, nlev+1, istartcol:iendcol) :: flux_up_clear, flux_dn_clear
+    real(jprb), dimension(ng, nlev+1, istartcol:iendcol) :: flux_up, flux_dn
+    real(jprb), dimension(ng, nlev+1, istartcol:iendcol) :: flux_up_clear, flux_dn_clear
 
     ! Identify clear-sky layers
     logical :: is_clear_sky_layer(nlev, istartcol:iendcol)
 
     ! workaround that allows inling of cloud generator
-    real(jprb), dimension(config%pdf_sampler%ncdf, config%pdf_sampler%nfsd)  :: sample_val
+    real(jprb), dimension(ncdf, nfsd)  :: sample_val
 
     ! temporary arrays to increase performance
     real(jprb), dimension(nlev, istartcol:iendcol) :: frac, frac_std
@@ -133,19 +235,19 @@ contains
 
     ! Diffuse reflectance and transmittance for each layer in clear
     ! and all skies
-    real(jprb), dimension(config%n_g_lw, nlev, istartcol:iendcol) :: trans_clear, reflectance, transmittance
+    real(jprb), dimension(ng, nlev, istartcol:iendcol) :: trans_clear, reflectance, transmittance
 
     ! Emission by a layer into the upwelling or downwelling diffuse
     ! streams, in clear and all skies
-    real(jprb), dimension(config%n_g_lw, nlev, istartcol:iendcol) :: source_up, source_dn
+    real(jprb), dimension(ng, nlev, istartcol:iendcol) :: source_up, source_dn
 
     ! Optical depth scaling from the cloud generator, zero indicating
     ! clear skies
-    real(jprb), dimension(config%n_g_lw,nlev, istartcol:iendcol) :: od_scaling
+    real(jprb), dimension(ng,nlev, istartcol:iendcol) :: od_scaling
     
         ! Temporary working array
-    real(jprb), dimension(config%n_g_lw,nlev+1, istartcol:iendcol) :: tmp_work_source
-    real(jprb), dimension(config%n_g_lw, istartcol:iendcol) :: tmp_derivatives
+    real(jprb), dimension(ng,nlev+1, istartcol:iendcol) :: tmp_work_source
+    real(jprb), dimension(ng, istartcol:iendcol) :: tmp_derivatives
 
     !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
     ! Local variables : Stack
@@ -160,7 +262,7 @@ contains
     real(jprb) :: od_total, ssa_total, g_total
 
     ! Combined scattering optical depth
-    real(jprb) :: scat_od, scat_od_total(config%n_g_lw)
+    real(jprb) :: scat_od, scat_od_total(ng)
 
     ! Total cloud cover output from the cloud generator
     real(jprb) :: total_cloud_cover
@@ -169,33 +271,16 @@ contains
     real(jprb) :: overlap_alpha
 
     ! Temporary storage for more efficient summation
-    real(jprb) :: sum_up, sum_dn, sum_up_clr, sum_dn_clr
+    real(jprb) :: sum_up, sum_dn, sum_up_clr, sum_dn_clr, weight
 
     ! Index of the highest cloudy layer
     integer :: i_cloud_top
 
-    ! Number of g points
-    integer :: ng
-
     ! Loop indices for level, column and g point
     integer :: jlev, jcol, jg
 
-    real(jphook) :: hook_handle
     !real(jprb)  totalMem
     integer :: file_idx, fidx1, fidx2, fidx3
-
-#ifdef HAVE_ROCTX
-    call roctxStartRange("radiation::mcica_omp_lw"//c_null_char)
-#endif
-
-    if (lhook) call dr_hook('radiation_mcica_omp_lw:solver_mcica_omp_lw',0,hook_handle)
-
-    if (.not. config%do_clear) then
-      write(nulerr,'(a)') '*** Error: longwave McICA OMP requires clear-sky calculation to be performed'
-      call radiation_abort()
-    end if
-
-    ng = config%n_g_lw
 
     !totalMem = 6*ng * nlev
     !totalMem = totalMem+5*(ng)*(nlev+1) !flux_up,dn,up_clear,dn_clear,source
@@ -207,8 +292,10 @@ contains
     !$OMP             sample_val, frac, frac_std, overlap_param, cum_cloud_cover, &
     !$OMP             pair_cloud_cover, cum_product, ibegin, iend)
 #if defined(__amdflang__)
-    !$OMP TARGET DATA MAP(PRESENT, ALLOC: config, single_level, cloud, od, ssa, g, od_cloud, ssa_cloud, &
-    !$OMP             g_cloud, planck_hl, emission, albedo, flux)
+    !$OMP TARGET DATA MAP(PRESENT, ALLOC: i_band_from_reordered_g_lw, pdf_val, iseed, &
+    !$OMP             cloud_fraction, cloud_fractional_std, cloud_overlap_param, od, ssa, g, &
+    !$OMP             od_cloud, ssa_cloud, g_cloud, planck_hl, emission, albedo, cloud_cover_lw, &
+    !$OMP             lw_dn_surf_clear_g, lw_dn_surf_g, lw_up_clear, lw_dn_clear, lw_up, lw_dn)
 #endif
 
     !
@@ -220,9 +307,9 @@ contains
     !$OMP   tmp_derivatives)
 
     !$OMP TARGET TEAMS DISTRIBUTE PARALLEL DO COLLAPSE(2)
-    do jlev = 1,config%pdf_sampler%nfsd
-      do jcol = 1,config%pdf_sampler%ncdf
-        sample_val(jcol,jlev) = config%pdf_sampler%val(jcol,jlev)
+    do jlev = 1,nfsd
+      do jcol = 1,ncdf
+        sample_val(jcol,jlev) = pdf_val(jcol,jlev)
       end do
     end do
     !$OMP END TARGET TEAMS DISTRIBUTE PARALLEL DO
@@ -230,8 +317,8 @@ contains
     !$OMP TARGET TEAMS DISTRIBUTE PARALLEL DO COLLAPSE(2)
     do jcol = istartcol,iendcol
       do jlev = 1, nlev
-        frac(jlev, jcol) = cloud%fraction(jcol,jlev)
-        frac_std(jlev, jcol) = cloud%fractional_std(jcol,jlev)
+        frac(jlev, jcol) = cloud_fraction(jcol,jlev)
+        frac_std(jlev, jcol) = cloud_fractional_std(jcol,jlev)
         is_clear_sky_layer(jlev,jcol) = .true.
       end do
     end do
@@ -240,7 +327,7 @@ contains
     !$OMP TARGET TEAMS DISTRIBUTE PARALLEL DO COLLAPSE(2)
     do jcol = istartcol,iendcol
       do jlev = 1, nlev-1
-        overlap_param(jlev, jcol) = cloud%overlap_param(jcol,jlev)
+        overlap_param(jlev, jcol) = cloud_overlap_param(jcol,jlev)
       end do
     end do
     !$OMP END TARGET TEAMS DISTRIBUTE PARALLEL DO
@@ -253,7 +340,7 @@ contains
       ! down to the base of each layer
       do jlev = 1,nlev-1
         ! Convert to "alpha" overlap parameter if necessary
-        if (config%use_beta_overlap) then
+        if (use_beta_overlap) then
           overlap_alpha = beta2alpha(overlap_param(jlev,jcol), &
                 &                     frac(jlev,jcol), frac(jlev+1,jcol))
         else
@@ -274,7 +361,6 @@ contains
       cum_product(jcol) = 1.0_jprb - frac(1,jcol)
       do jlev = 1,nlev-1
         if (frac(jlev,jcol) >= MaxCloudFrac) then
-          ! Cloud cover has reached one
           cum_product(jcol) = 0.0_jprb
         else
           cum_product(jcol) = cum_product(jcol) * (1.0_jprb - pair_cloud_cover(jlev, jcol)) &
@@ -282,18 +368,16 @@ contains
         end if
         cum_cloud_cover(jlev+1, jcol) = 1.0_jprb - cum_product(jcol)
       end do
-      flux%cloud_cover_lw(jcol) = cum_cloud_cover(nlev,jcol);
-      if (flux%cloud_cover_lw(jcol) < config%cloud_fraction_threshold) then
-        ! Treat column as clear sky: calling function therefore will not
-        ! use od_scaling so we don't need to calculate it
-        flux%cloud_cover_lw(jcol) = 0.0_jprb
+      cloud_cover_lw(jcol) = cum_cloud_cover(nlev,jcol)
+      if (cloud_cover_lw(jcol) < cloud_fraction_threshold) then
+        cloud_cover_lw(jcol) = 0.0_jprb
       end if
     end do
     !$OMP END TARGET TEAMS DISTRIBUTE PARALLEL DO
 
     !$OMP TARGET TEAMS DISTRIBUTE PARALLEL DO
     do jcol = istartcol,iendcol
-      if (flux%cloud_cover_lw(jcol) >= config%cloud_fraction_threshold) then
+      if (cloud_cover_lw(jcol) >= cloud_fraction_threshold) then
         ! Cloud is present: need to calculate od_scaling
         ! Find range of cloudy layers
         ibegin(jcol) = nlev
@@ -334,22 +418,25 @@ contains
     do jcol = istartcol,iendcol
        do jg = 1, ng
           call cloud_generator_omp(jg, ng, nlev, &
-               &  single_level%iseed(jcol) + 997, &
-               &  config%cloud_fraction_threshold, &
+               &  iseed(jcol) + 997, &
+               &  cloud_fraction_threshold, &
                &  frac(:,jcol), overlap_param(:,jcol), &
-               &  config%cloud_inhom_decorr_scaling, frac_std(:,jcol), &
-               &  config%pdf_sampler%ncdf, config%pdf_sampler%nfsd, &
-               &  config%pdf_sampler%fsd1, config%pdf_sampler%inv_fsd_interval, &
+               &  cloud_inhom_decorr_scaling, frac_std(:,jcol), &
+               &  ncdf, nfsd, &
+               &  fsd1, inv_fsd_interval, &
                &  sample_val, &
-               &  od_scaling(:,:,jcol), flux%cloud_cover_lw(jcol)+0.0_jprb, & ! Workaround for nvhpc-24.1
+               &  od_scaling(:,:,jcol), cloud_cover_lw(jcol)+0.0_jprb, & ! Workaround for nvhpc-24.1
                &  ibegin(jcol), iend(jcol), &
                &  cum_cloud_cover=cum_cloud_cover(:,jcol), &
                &  pair_cloud_cover=pair_cloud_cover(:,jcol))
        enddo
     enddo
 
-    !$OMP TARGET TEAMS DISTRIBUTE PARALLEL DO COLLAPSE(2) PRIVATE(od_cloud_new, od_total, ssa_total, g_total, scat_od, &
-    !$OMP& jcol, jg, jlev, i_cloud_top) FIRSTPRIVATE(istartcol, iendcol, ng, nlev) THREAD_LIMIT(1024)
+    ! Split the former combined kernel so the always-on clear-sky path is not
+    ! compiled together with cloudy two-stream/adding (high VGPR/scratch).
+    ! Revert: restore radiation_mcica_omp_lw.F90.pre_split_l435
+    !$OMP TARGET TEAMS DISTRIBUTE PARALLEL DO COLLAPSE(2) PRIVATE(jcol, jg) &
+    !$OMP& FIRSTPRIVATE(istartcol, iendcol, ng, nlev) THREAD_LIMIT(1024)
     do jcol = istartcol,iendcol
        do jg = 1, ng
           ! Clear-sky calculation
@@ -366,17 +453,24 @@ contains
                &  flux_up_clear(:,:,jcol), flux_dn_clear(:,:,jcol))
 
           ! Store surface spectral downwelling fluxes
-          flux%lw_dn_surf_clear_g(jg,jcol) = flux_dn_clear(jg,nlev+1,jcol)
+          lw_dn_surf_clear_g(jg,jcol) = flux_dn_clear(jg,nlev+1,jcol)
+       end do
+    end do
+    !$OMP END TARGET TEAMS DISTRIBUTE PARALLEL DO
+
+    !$OMP TARGET TEAMS DISTRIBUTE PARALLEL DO COLLAPSE(2) PRIVATE(od_cloud_new, od_total, ssa_total, g_total, scat_od, &
+    !$OMP& jcol, jg, jlev, i_cloud_top) FIRSTPRIVATE(istartcol, iendcol, ng, nlev) THREAD_LIMIT(1024)
+    do jcol = istartcol,iendcol
+       do jg = 1, ng
           ! Do cloudy-sky calculation; add a prime number to the seed in
           ! the longwave
-
-          if (flux%cloud_cover_lw(jcol) >= config%cloud_fraction_threshold) then
+          if (cloud_cover_lw(jcol) >= cloud_fraction_threshold) then
              ! Total-sky calculation
              i_cloud_top = nlev+1
 
              do jlev = 1,nlev
                 ! Compute combined gas+aerosol+cloud optical properties
-                if (frac(jlev,jcol) >= config%cloud_fraction_threshold) then
+                if (frac(jlev,jcol) >= cloud_fraction_threshold) then
                    is_clear_sky_layer(jlev,jcol) = .false.
                    ! Get index to the first cloudy layer from the top
                    if (i_cloud_top > jlev) then
@@ -384,21 +478,21 @@ contains
                    end if
                    
                    od_cloud_new = od_scaling(jg,jlev,jcol) &
-                        &  * od_cloud(config%i_band_from_reordered_g_lw(jg),jlev,jcol)
+                        &  * od_cloud(i_band_from_reordered_g_lw(jg),jlev,jcol)
                    od_total  = od(jg,jlev,jcol) + od_cloud_new
                    ssa_total = 0.0_jprb
                    g_total   = 0.0_jprb
 
-                   if (config%do_lw_cloud_scattering) then
+                   if (do_lw_cloud_scattering) then
                       ! Scattering case: calculate reflectance and
                       ! transmittance at each model level
                       if (od_total > 0.0_jprb) then
-                         scat_od = ssa_cloud(config%i_band_from_reordered_g_lw(jg),jlev,jcol) &
+                         scat_od = ssa_cloud(i_band_from_reordered_g_lw(jg),jlev,jcol) &
                               &     * od_cloud_new
                          ssa_total = scat_od / od_total
                          if (scat_od > 0.0_jprb) then
-                            g_total = g_cloud(config%i_band_from_reordered_g_lw(jg),jlev,jcol) &
-                                 &     * ssa_cloud(config%i_band_from_reordered_g_lw(jg),jlev,jcol) &
+                            g_total = g_cloud(i_band_from_reordered_g_lw(jg),jlev,jcol) &
+                                 &     * ssa_cloud(i_band_from_reordered_g_lw(jg),jlev,jcol) &
                                  &     *  od_cloud_new / scat_od
                          end if
                       end if
@@ -425,7 +519,7 @@ contains
                 end if
              end do
 
-             if(config%do_lw_cloud_scattering) then
+             if(do_lw_cloud_scattering) then
                 ! Use adding method to compute fluxes but optimize for the
                 ! presence of clear-sky layers
                 call fast_adding_ica_lw_omp(jg, ng, nlev, reflectance(:,:,jcol), transmittance(:,:,jcol), &
@@ -446,44 +540,134 @@ contains
              ! Cloudy flux profiles currently assume completely overcast
              ! skies; perform weighted average with clear-sky profile
              ! Store surface spectral downwelling fluxes
-             flux%lw_dn_surf_g(jg,jcol) = flux%cloud_cover_lw(jcol)*flux_dn(jg,nlev+1,jcol) &
-                  &  + (1.0_jprb - flux%cloud_cover_lw(jcol))*flux%lw_dn_surf_clear_g(jg,jcol)
+             lw_dn_surf_g(jg,jcol) = cloud_cover_lw(jcol)*flux_dn(jg,nlev+1,jcol) &
+                  &  + (1.0_jprb - cloud_cover_lw(jcol))*lw_dn_surf_clear_g(jg,jcol)
           else
              ! No cloud in profile and clear-sky fluxes already
              ! calculated: copy them over
-             flux%lw_dn_surf_g(jg,jcol) = flux%lw_dn_surf_clear_g(jg,jcol)
+             lw_dn_surf_g(jg,jcol) = lw_dn_surf_clear_g(jg,jcol)
           end if
        end do
     end do
     !$OMP END TARGET TEAMS DISTRIBUTE PARALLEL DO
 
     !
-    ! Separate out the derivative computation, which has reductions across spectral bands
+    ! LW derivatives: two-pass so the vertical product is (jcol,jg) like the
+    ! flux kernels, then a cheap sum over g-points. Spectral products go into
+    ! tmp_work_source (scratch after adding). Arithmetic matches the old
+    ! calc/modify_lw_derivatives_ica_omp loops (same jg order).
+    ! Revert: restore radiation_mcica_omp_lw.F90.pre_deriv_twopass
     !
-    if (config%do_lw_derivatives) then
-      !$OMP TARGET TEAMS DISTRIBUTE PARALLEL DO THREAD_LIMIT(64)
+    if (do_lw_derivatives) then
+      !$OMP TARGET TEAMS DISTRIBUTE PARALLEL DO PRIVATE(jcol, jg, sum_up, sum_up_clr) &
+      !$OMP& FIRSTPRIVATE(istartcol, iendcol, ng, nlev) THREAD_LIMIT(16)
       do jcol = istartcol,iendcol
-        if (flux%cloud_cover_lw(jcol) >= config%cloud_fraction_threshold) then
-          call calc_lw_derivatives_ica_omp(ng, nlev, jcol, transmittance(:,:,jcol), flux_up(:,nlev+1,jcol), &
-               &                       flux%lw_derivatives, tmp_derivatives(:,jcol))
-          if (flux%cloud_cover_lw(jcol) < 1.0_jprb - config%cloud_fraction_threshold) then
-            ! Modify the existing derivative with the contribution from the clear sky
-            call modify_lw_derivatives_ica_omp(ng, nlev, jcol, trans_clear(:,:,jcol), flux_up_clear(:,nlev+1,jcol), &
-                 &                             1.0_jprb-flux%cloud_cover_lw(jcol), flux%lw_derivatives, tmp_derivatives(:,jcol))
-          end if
+        if (cloud_cover_lw(jcol) >= cloud_fraction_threshold) then
+          sum_up = 0.0_jprb
+          do jg = 1, ng
+            sum_up = sum_up + flux_up(jg,nlev+1,jcol)
+          end do
+          cum_product(jcol) = sum_up
         else
-          call calc_lw_derivatives_ica_omp(ng, nlev, jcol, trans_clear(:,:,jcol), flux_up_clear(:,nlev+1,jcol), &
-               &                       flux%lw_derivatives, tmp_derivatives(:,jcol))
-        endif
-      enddo
+          sum_up_clr = 0.0_jprb
+          do jg = 1, ng
+            sum_up_clr = sum_up_clr + flux_up_clear(jg,nlev+1,jcol)
+          end do
+          cum_product(jcol) = sum_up_clr
+        end if
+      end do
+      !$OMP END TARGET TEAMS DISTRIBUTE PARALLEL DO
+
+      !$OMP TARGET TEAMS DISTRIBUTE PARALLEL DO COLLAPSE(2) PRIVATE(jcol, jg, jlev, sum_up) &
+      !$OMP& FIRSTPRIVATE(istartcol, iendcol, ng, nlev) THREAD_LIMIT(1024)
+      do jcol = istartcol,iendcol
+        do jg = 1, ng
+          if (cloud_cover_lw(jcol) >= cloud_fraction_threshold) then
+            sum_up = flux_up(jg,nlev+1,jcol) / cum_product(jcol)
+            do jlev = nlev,1,-1
+              sum_up = sum_up * transmittance(jg,jlev,jcol)
+              tmp_work_source(jg,jlev,jcol) = sum_up
+            end do
+          else
+            sum_up = flux_up_clear(jg,nlev+1,jcol) / cum_product(jcol)
+            do jlev = nlev,1,-1
+              sum_up = sum_up * trans_clear(jg,jlev,jcol)
+              tmp_work_source(jg,jlev,jcol) = sum_up
+            end do
+          end if
+        end do
+      end do
+      !$OMP END TARGET TEAMS DISTRIBUTE PARALLEL DO
+
+      !$OMP TARGET TEAMS DISTRIBUTE PARALLEL DO COLLAPSE(2) PRIVATE(jcol, jlev, jg, sum_up) &
+      !$OMP& FIRSTPRIVATE(istartcol, iendcol, ng, nlev) THREAD_LIMIT(32)
+      do jcol = istartcol,iendcol
+        do jlev = 1, nlev+1
+          if (jlev == nlev+1) then
+            lw_derivatives(jcol,jlev) = 1.0_jprb
+          else
+            sum_up = 0.0_jprb
+            do jg = 1, ng
+              sum_up = sum_up + tmp_work_source(jg,jlev,jcol)
+            end do
+            lw_derivatives(jcol,jlev) = sum_up
+          end if
+        end do
+      end do
+      !$OMP END TARGET TEAMS DISTRIBUTE PARALLEL DO
+
+      !$OMP TARGET TEAMS DISTRIBUTE PARALLEL DO PRIVATE(jcol, jg, sum_up_clr) &
+      !$OMP& FIRSTPRIVATE(istartcol, iendcol, ng, nlev) THREAD_LIMIT(16)
+      do jcol = istartcol,iendcol
+        if (cloud_cover_lw(jcol) >= cloud_fraction_threshold .and. &
+             &  cloud_cover_lw(jcol) < 1.0_jprb - cloud_fraction_threshold) then
+          sum_up_clr = 0.0_jprb
+          do jg = 1, ng
+            sum_up_clr = sum_up_clr + flux_up_clear(jg,nlev+1,jcol)
+          end do
+          cum_product(jcol) = sum_up_clr
+        end if
+      end do
+      !$OMP END TARGET TEAMS DISTRIBUTE PARALLEL DO
+
+      !$OMP TARGET TEAMS DISTRIBUTE PARALLEL DO COLLAPSE(2) PRIVATE(jcol, jg, jlev, sum_up) &
+      !$OMP& FIRSTPRIVATE(istartcol, iendcol, ng, nlev) THREAD_LIMIT(1024)
+      do jcol = istartcol,iendcol
+        do jg = 1, ng
+          if (cloud_cover_lw(jcol) >= cloud_fraction_threshold .and. &
+               &  cloud_cover_lw(jcol) < 1.0_jprb - cloud_fraction_threshold) then
+            sum_up = flux_up_clear(jg,nlev+1,jcol) / cum_product(jcol)
+            do jlev = nlev,1,-1
+              sum_up = sum_up * trans_clear(jg,jlev,jcol)
+              tmp_work_source(jg,jlev,jcol) = sum_up
+            end do
+          end if
+        end do
+      end do
+      !$OMP END TARGET TEAMS DISTRIBUTE PARALLEL DO
+
+      !$OMP TARGET TEAMS DISTRIBUTE PARALLEL DO COLLAPSE(2) PRIVATE(jcol, jlev, jg, sum_up, weight) &
+      !$OMP& FIRSTPRIVATE(istartcol, iendcol, ng, nlev) THREAD_LIMIT(32)
+      do jcol = istartcol,iendcol
+        do jlev = 1, nlev
+          if (cloud_cover_lw(jcol) >= cloud_fraction_threshold .and. &
+               &  cloud_cover_lw(jcol) < 1.0_jprb - cloud_fraction_threshold) then
+            weight = 1.0_jprb - cloud_cover_lw(jcol)
+            sum_up = 0.0_jprb
+            do jg = 1, ng
+              sum_up = sum_up + tmp_work_source(jg,jlev,jcol)
+            end do
+            lw_derivatives(jcol,jlev) = (1.0_jprb - weight) * lw_derivatives(jcol,jlev) &
+                 &                    + weight * sum_up
+          end if
+        end do
+      end do
       !$OMP END TARGET TEAMS DISTRIBUTE PARALLEL DO
     endif
 
     ! Loop through columns
-    !$OMP TARGET TEAMS DISTRIBUTE PARALLEL DO COLLAPSE(2) PRIVATE(total_cloud_cover, sum_up, sum_dn, sum_up_clr, sum_dn_clr)
-#if defined(__amdflang__)
-    !$OMP TILE SIZES(64,1)
-#endif
+    !$OMP TARGET TEAMS DISTRIBUTE PARALLEL DO COLLAPSE(2) &
+    !$OMP& PRIVATE(total_cloud_cover, sum_up, sum_dn, sum_up_clr, sum_dn_clr) THREAD_LIMIT(32)
     do jcol = istartcol,iendcol
        do jlev = 1,nlev+1
 
@@ -493,11 +677,11 @@ contains
           sum_up_clr = sum_up_clr + flux_up_clear(jg,jlev,jcol)
           sum_dn_clr = sum_dn_clr + flux_dn_clear(jg,jlev,jcol)
         end do
-        flux%lw_up_clear(jcol,jlev) = sum_up_clr
-        flux%lw_dn_clear(jcol,jlev) = sum_dn_clr
+        lw_up_clear(jcol,jlev) = sum_up_clr
+        lw_dn_clear(jcol,jlev) = sum_dn_clr
 
-        total_cloud_cover = flux%cloud_cover_lw(jcol)
-        if (total_cloud_cover >= config%cloud_fraction_threshold) then
+        total_cloud_cover = cloud_cover_lw(jcol)
+        if (total_cloud_cover >= cloud_fraction_threshold) then
 
           ! Store overcast broadband fluxes
           sum_up = 0._jprb
@@ -506,20 +690,17 @@ contains
             sum_up = sum_up + flux_up(jg,jlev,jcol)
             sum_dn = sum_dn + flux_dn(jg,jlev,jcol)
           end do
-          flux%lw_up(jcol,jlev) = total_cloud_cover*sum_up + (1.0_jprb - total_cloud_cover)*sum_up_clr
-          flux%lw_dn(jcol,jlev) = total_cloud_cover*sum_dn + (1.0_jprb - total_cloud_cover)*sum_dn_clr
+          lw_up(jcol,jlev) = total_cloud_cover*sum_up + (1.0_jprb - total_cloud_cover)*sum_up_clr
+          lw_dn(jcol,jlev) = total_cloud_cover*sum_dn + (1.0_jprb - total_cloud_cover)*sum_dn_clr
 
         else
 
-          flux%lw_up(jcol,jlev) = sum_up_clr
-          flux%lw_dn(jcol,jlev) = sum_dn_clr
+          lw_up(jcol,jlev) = sum_up_clr
+          lw_dn(jcol,jlev) = sum_dn_clr
 
         end if
       end do
     end do
-#if defined(__amdflang__)
-    !$OMP END TILE
-#endif
     !$OMP END TARGET TEAMS DISTRIBUTE PARALLEL DO
 
     !$OMP TARGET EXIT DATA MAP(DELETE: trans_clear, od_scaling, &
@@ -535,11 +716,6 @@ contains
     !$OMP END TARGET DATA
 #endif
 
-#ifdef HAVE_ROCTX
-    call roctxEndRange
-#endif
-    if (lhook) call dr_hook('radiation_mcica_omp_lw:solver_mcica_omp_lw',1,hook_handle)
-
-  end subroutine solver_mcica_omp_lw
+  end subroutine solver_mcica_omp_lw_impl
 
 end module radiation_mcica_omp_lw

--- a/radiation/radiation_mcica_omp_sw.F90
+++ b/radiation/radiation_mcica_omp_sw.F90
@@ -23,6 +23,7 @@ module radiation_mcica_omp_sw
 
   use radiation_io, only : nulout
   public
+  private :: solver_mcica_omp_sw_impl
 
 contains
 
@@ -47,20 +48,11 @@ contains
 
     use parkind1, only           : jprb
     use yomhook,  only           : lhook, dr_hook, jphook
-
     use radiation_io,   only           : nulerr, radiation_abort
     use radiation_config, only         : config_type
     use radiation_single_level, only   : single_level_type
     use radiation_cloud, only          : cloud_type
     use radiation_flux, only           : flux_type
-    use radiation_two_stream, only     : calc_two_stream_gammas_sw_single_band_omp, &
-         &                               calc_reflectance_transmittance_sw_single_band_omp, &
-         &                               calc_ref_trans_sw_omp, calc_ref_trans_sw_single_level_omp
-    
-    use radiation_adding_ica_sw, only  : adding_ica_sw_omp
-    use radiation_cloud_generator_acc, only: cloud_generator_omp
-    use radiation_cloud_cover, only    : beta2alpha, MaxCloudFrac
-
 #ifdef HAVE_ROCTX
     use roctx_profiling, only: roctxstartrange, roctxendrange
     use iso_c_binding, only: c_null_char
@@ -68,42 +60,134 @@ contains
 
     implicit none
 
-    ! Inputs
-    integer, intent(in) :: nlev               ! number of model levels
-    integer, intent(in) :: istartcol, iendcol ! range of columns to process
+    integer, intent(in) :: nlev
+    integer, intent(in) :: istartcol, iendcol
     type(config_type),        intent(in) :: config
     type(single_level_type),  intent(in) :: single_level
     type(cloud_type),         intent(in) :: cloud
-
-    ! Gas and aerosol optical depth, single-scattering albedo and
-    ! asymmetry factor at each shortwave g-point
     real(jprb), intent(in), dimension(config%n_g_sw, nlev, istartcol:iendcol) :: &
          &  od, ssa, g
-
-    ! Cloud and precipitation optical depth, single-scattering albedo and
-    ! asymmetry factor in each shortwave band
     real(jprb), intent(in), dimension(config%n_bands_sw,nlev,istartcol:iendcol)   :: &
          &  od_cloud, ssa_cloud, g_cloud
-
-    ! Direct and diffuse surface albedos, and the incoming shortwave
-    ! flux into a plane perpendicular to the incoming radiation at
-    ! top-of-atmosphere in each of the shortwave g points
     real(jprb), intent(in), dimension(config%n_g_sw,istartcol:iendcol) :: &
          &  albedo_direct, albedo_diffuse, incoming_sw
-
-    ! Output
     type(flux_type), intent(inout):: flux
+
+    real(jphook) :: hook_handle
+
+#ifdef HAVE_ROCTX
+    call roctxStartRange("radiation::mcica_omp_sw"//c_null_char)
+#endif
+    if (lhook) call dr_hook('radiation_mcica_omp_sw:solver_mcica_omp_sw',0,hook_handle)
+
+    if (.not. config%do_clear) then
+      write(nulerr,'(a)') '*** Error: shortwave McICA OMP requires clear-sky calculation to be performed'
+      call radiation_abort()
+    end if
+
+    if (allocated(flux%sw_dn_direct) .and. allocated(flux%sw_dn_direct_clear)) then
+      call solver_mcica_omp_sw_impl(nlev, size(cloud%fraction,1), istartcol, iendcol, config%n_g_sw, &
+           & config%pdf_sampler%ncdf, config%pdf_sampler%nfsd, config%n_bands_sw, &
+           & config%use_beta_overlap, &
+           & config%do_sw_delta_scaling_with_gases, &
+           & config%cloud_fraction_threshold, config%cloud_inhom_decorr_scaling, &
+           & config%pdf_sampler%fsd1, config%pdf_sampler%inv_fsd_interval, &
+           & config%i_band_from_reordered_g_sw, config%pdf_sampler%val, &
+           & single_level%iseed, single_level%cos_sza, &
+           & cloud%fraction, cloud%fractional_std, cloud%overlap_param, &
+           & od, ssa, g, od_cloud, ssa_cloud, g_cloud, &
+           & albedo_direct, albedo_diffuse, incoming_sw, &
+           & flux%cloud_cover_sw, flux%sw_dn_diffuse_surf_clear_g, flux%sw_dn_direct_surf_clear_g, &
+           & flux%sw_dn_diffuse_surf_g, flux%sw_dn_direct_surf_g, &
+           & flux%sw_up_clear, flux%sw_dn_clear, flux%sw_up, flux%sw_dn, &
+           & flux%sw_dn_direct, flux%sw_dn_direct_clear)
+    else
+      call solver_mcica_omp_sw_impl(nlev, size(cloud%fraction,1), istartcol, iendcol, config%n_g_sw, &
+           & config%pdf_sampler%ncdf, config%pdf_sampler%nfsd, config%n_bands_sw, &
+           & config%use_beta_overlap, &
+           & config%do_sw_delta_scaling_with_gases, &
+           & config%cloud_fraction_threshold, config%cloud_inhom_decorr_scaling, &
+           & config%pdf_sampler%fsd1, config%pdf_sampler%inv_fsd_interval, &
+           & config%i_band_from_reordered_g_sw, config%pdf_sampler%val, &
+           & single_level%iseed, single_level%cos_sza, &
+           & cloud%fraction, cloud%fractional_std, cloud%overlap_param, &
+           & od, ssa, g, od_cloud, ssa_cloud, g_cloud, &
+           & albedo_direct, albedo_diffuse, incoming_sw, &
+           & flux%cloud_cover_sw, flux%sw_dn_diffuse_surf_clear_g, flux%sw_dn_direct_surf_clear_g, &
+           & flux%sw_dn_diffuse_surf_g, flux%sw_dn_direct_surf_g, &
+           & flux%sw_up_clear, flux%sw_dn_clear, flux%sw_up, flux%sw_dn)
+    end if
+
+#ifdef HAVE_ROCTX
+    call roctxEndRange
+#endif
+    if (lhook) call dr_hook('radiation_mcica_omp_sw:solver_mcica_omp_sw',1,hook_handle)
+
+  end subroutine solver_mcica_omp_sw
+
+  subroutine solver_mcica_omp_sw_impl(nlev, ncol, istartcol, iendcol, ng, ncdf, nfsd, n_bands, &
+       & use_beta_overlap, do_sw_delta_scaling_with_gases, &
+       & cloud_fraction_threshold, cloud_inhom_decorr_scaling, fsd1, inv_fsd_interval, &
+       & i_band_from_reordered_g_sw, pdf_val, iseed, cos_sza_col, &
+       & cloud_fraction, cloud_fractional_std, cloud_overlap_param, &
+       & od, ssa, g, od_cloud, ssa_cloud, g_cloud, &
+       & albedo_direct, albedo_diffuse, incoming_sw, &
+       & cloud_cover_sw, sw_dn_diffuse_surf_clear_g, sw_dn_direct_surf_clear_g, &
+       & sw_dn_diffuse_surf_g, sw_dn_direct_surf_g, &
+       & sw_up_clear, sw_dn_clear, sw_up, sw_dn, sw_dn_direct, sw_dn_direct_clear)
+
+    use parkind1, only           : jprb
+    use radiation_two_stream, only     : calc_two_stream_gammas_sw_single_band_omp, &
+         &                               calc_reflectance_transmittance_sw_single_band_omp, &
+         &                               calc_ref_trans_sw_omp, calc_ref_trans_sw_single_level_omp
+    use radiation_adding_ica_sw, only  : adding_ica_sw_omp
+    use radiation_cloud_generator_acc, only: cloud_generator_omp
+    use radiation_cloud_cover, only    : beta2alpha, MaxCloudFrac
+
+    implicit none
+
+    integer, intent(in) :: nlev, ncol, istartcol, iendcol, ng, ncdf, nfsd, n_bands
+    logical, intent(in) :: use_beta_overlap, do_sw_delta_scaling_with_gases
+    real(jprb), intent(in) :: cloud_fraction_threshold, cloud_inhom_decorr_scaling
+    real(jprb), intent(in) :: fsd1, inv_fsd_interval
+    integer, intent(in) :: i_band_from_reordered_g_sw(ng)
+    real(jprb), intent(in) :: pdf_val(ncdf,nfsd)
+    integer, intent(in) :: iseed(ncol)
+    real(jprb), intent(in) :: cos_sza_col(ncol)
+    real(jprb), intent(in) :: cloud_fraction(ncol,nlev)
+    real(jprb), intent(in) :: cloud_fractional_std(ncol,nlev)
+    real(jprb), intent(in) :: cloud_overlap_param(ncol,nlev-1)
+    real(jprb), intent(in) :: od(ng,nlev,istartcol:iendcol)
+    real(jprb), intent(in) :: ssa(ng,nlev,istartcol:iendcol)
+    real(jprb), intent(in) :: g(ng,nlev,istartcol:iendcol)
+    real(jprb), intent(in) :: od_cloud(n_bands,nlev,istartcol:iendcol)
+    real(jprb), intent(in) :: ssa_cloud(n_bands,nlev,istartcol:iendcol)
+    real(jprb), intent(in) :: g_cloud(n_bands,nlev,istartcol:iendcol)
+    real(jprb), intent(in) :: albedo_direct(ng,istartcol:iendcol)
+    real(jprb), intent(in) :: albedo_diffuse(ng,istartcol:iendcol)
+    real(jprb), intent(in) :: incoming_sw(ng,istartcol:iendcol)
+    real(jprb), intent(inout) :: cloud_cover_sw(ncol)
+    real(jprb), intent(inout) :: sw_dn_diffuse_surf_clear_g(ng,ncol)
+    real(jprb), intent(inout) :: sw_dn_direct_surf_clear_g(ng,ncol)
+    real(jprb), intent(inout) :: sw_dn_diffuse_surf_g(ng,ncol)
+    real(jprb), intent(inout) :: sw_dn_direct_surf_g(ng,ncol)
+    real(jprb), intent(inout) :: sw_up_clear(ncol,nlev+1)
+    real(jprb), intent(inout) :: sw_dn_clear(ncol,nlev+1)
+    real(jprb), intent(inout) :: sw_up(ncol,nlev+1)
+    real(jprb), intent(inout) :: sw_dn(ncol,nlev+1)
+    real(jprb), intent(inout), optional :: sw_dn_direct(ncol,nlev+1)
+    real(jprb), intent(inout), optional :: sw_dn_direct_clear(ncol,nlev+1)
 
     !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
     ! Local variables : Mapped into Global Memory
     !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 
     ! Fluxes per g point
-    real(jprb), dimension(config%n_g_sw, nlev+1, istartcol:iendcol) :: flux_up, flux_dn_diffuse, flux_dn_direct
-    real(jprb), dimension(config%n_g_sw, nlev+1, istartcol:iendcol) :: flux_up_clear, flux_dn_diffuse_clear, flux_dn_direct_clear
+    real(jprb), dimension(ng, nlev+1, istartcol:iendcol) :: flux_up, flux_dn_diffuse, flux_dn_direct
+    real(jprb), dimension(ng, nlev+1, istartcol:iendcol) :: flux_up_clear, flux_dn_diffuse_clear, flux_dn_direct_clear
 
     ! workaround that allows inling of cloud generator
-    real(jprb), dimension(config%pdf_sampler%ncdf, config%pdf_sampler%nfsd) :: sample_val
+    real(jprb), dimension(ncdf, nfsd) :: sample_val
 
     ! copies to increase performance
     real(jprb), dimension(nlev, istartcol:iendcol) :: frac, frac_std
@@ -123,26 +207,26 @@ contains
     !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 
     ! Transmittance for the direct beam in clear and all skies
-    real(jprb), dimension(config%n_g_sw, nlev, istartcol:iendcol) :: ref_clear,  trans_clear, ref_dir_clear
-    !real(jprb), dimension(config%n_g_sw, nlev, istartcol:iendcol) :: trans_dir_diff_clear, trans_dir_dir_clear
+    real(jprb), dimension(ng, nlev, istartcol:iendcol) :: ref_clear,  trans_clear, ref_dir_clear
+    !real(jprb), dimension(ng, nlev, istartcol:iendcol) :: trans_dir_diff_clear, trans_dir_dir_clear
 
     ! Fraction of direct beam scattered by a layer into the upwelling
     ! or downwelling diffuse streams, in clear and all skies
-    real(jprb), dimension(config%n_g_sw, nlev, istartcol:iendcol) :: ref_dir, trans_dir_diff
+    real(jprb), dimension(ng, nlev, istartcol:iendcol) :: ref_dir, trans_dir_diff
 
     ! Transmittance for the direct beam in clear and all skies
-    real(jprb), dimension(config%n_g_sw, nlev, istartcol:iendcol) :: trans_dir_dir
+    real(jprb), dimension(ng, nlev, istartcol:iendcol) :: trans_dir_dir
 
     ! Diffuse reflectance and transmittance for each layer in clear
     ! and all skies
-    real(jprb), dimension(config%n_g_sw, nlev, istartcol:iendcol) :: reflectance, transmittance
+    real(jprb), dimension(ng, nlev, istartcol:iendcol) :: reflectance, transmittance
 
     ! Optical depth scaling from the cloud generator, zero indicating
     ! clear skies
-    real(jprb), dimension(config%n_g_sw,nlev,istartcol:iendcol) :: od_scaling
+    real(jprb), dimension(ng,nlev,istartcol:iendcol) :: od_scaling
 
     ! Temporary working array
-    real(jprb), dimension(config%n_g_sw,nlev+1,istartcol:iendcol) :: tmp_work_source
+    real(jprb), dimension(ng,nlev+1,istartcol:iendcol) :: tmp_work_source
 
     !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
     ! Local variables : Stack
@@ -171,26 +255,11 @@ contains
     ! Auxiliary for more efficient summation
     real(jprb) :: sum_up, sum_dn_direct, sum_dn_diffuse
 
-    ! Number of g points
-    integer :: ng
-
     ! Loop indices for level, column and g point
     integer :: jlev, jcol, jg
     !real(jprb)  totalMem
-    real(jphook) :: hook_handle
 
-#ifdef HAVE_ROCTX
-    call roctxStartRange("radiation::mcica_omp_sw"//c_null_char)
-#endif
-
-    if (lhook) call dr_hook('radiation_mcica_omp_sw:solver_mcica_omp_sw',0,hook_handle)
-
-    if (.not. config%do_clear) then
-      write(nulerr,'(a)') '*** Error: shortwave McICA OMP requires clear-sky calculation to be performed'
-      call radiation_abort()
-    end if
-
-    !$OMP TARGET ENTER DATA MAP(ALLOC: ref_clear,  trans_clear, ref_dir_clear, &
+!$OMP TARGET ENTER DATA MAP(ALLOC: ref_clear,  trans_clear, ref_dir_clear, &
     !$OMP&   od_scaling, tmp_work_source,&
     !$OMP&   ref_dir, trans_dir_diff, trans_dir_dir, reflectance, transmittance)
     !$OMP TARGET ENTER DATA MAP(ALLOC: flux_up, flux_dn_diffuse, flux_dn_direct, &
@@ -198,12 +267,15 @@ contains
     !$OMP             sample_val, frac, frac_std, overlap_param, &
     !$OMP             cum_cloud_cover, pair_cloud_cover, cum_product, ibegin, iend)
 #if defined(__amdflang__)
-    !$OMP TARGET DATA MAP(PRESENT, ALLOC: config, single_level, cloud, od, ssa, g, od_cloud, &
-    !$OMP             ssa_cloud, g_cloud, albedo_direct, albedo_diffuse, &
-    !$OMP             incoming_sw, flux)
+    !$OMP TARGET DATA MAP(PRESENT, ALLOC: od, ssa, g, od_cloud, ssa_cloud, g_cloud, &
+    !$OMP             albedo_direct, albedo_diffuse, incoming_sw, pdf_val, iseed, cos_sza_col, &
+    !$OMP             cloud_fraction, cloud_fractional_std, cloud_overlap_param, &
+    !$OMP             i_band_from_reordered_g_sw, cloud_cover_sw, &
+    !$OMP             sw_dn_diffuse_surf_clear_g, sw_dn_direct_surf_clear_g, &
+    !$OMP             sw_dn_diffuse_surf_g, sw_dn_direct_surf_g, &
+    !$OMP             sw_up_clear, sw_dn_clear, sw_up, sw_dn)
 #endif
 
-    ng = config%n_g_sw
 
     !totalMem = 9*ng * nlev
     !totalMem = totalMem+7*(ng)*(nlev+1) !flux_up,dn,up_clear,dn_clear,source
@@ -211,9 +283,9 @@ contains
     !write(nulout,'(a,a,i0,a,g0.5)') __FILE__, " : LINE = ", __LINE__, " total_memory=",totalMem
 
     !$OMP TARGET TEAMS DISTRIBUTE PARALLEL DO COLLAPSE(2)
-    do jlev = 1,config%pdf_sampler%nfsd
-      do jcol = 1,config%pdf_sampler%ncdf
-        sample_val(jcol,jlev) = config%pdf_sampler%val(jcol,jlev)
+    do jlev = 1,nfsd
+      do jcol = 1,ncdf
+        sample_val(jcol,jlev) = pdf_val(jcol,jlev)
       end do
     end do
     !$OMP END TARGET TEAMS DISTRIBUTE PARALLEL DO
@@ -221,8 +293,8 @@ contains
     !$OMP TARGET TEAMS DISTRIBUTE PARALLEL DO COLLAPSE(2)
     do jcol = istartcol,iendcol
       do jlev = 1, nlev
-        frac(jlev, jcol) = cloud%fraction(jcol,jlev)
-        frac_std(jlev, jcol) = cloud%fractional_std(jcol,jlev)
+        frac(jlev, jcol) = cloud_fraction(jcol,jlev)
+        frac_std(jlev, jcol) = cloud_fractional_std(jcol,jlev)
       end do
     end do
     !$OMP END TARGET TEAMS DISTRIBUTE PARALLEL DO
@@ -230,7 +302,7 @@ contains
     !$OMP TARGET TEAMS DISTRIBUTE PARALLEL DO COLLAPSE(2)
     do jcol = istartcol,iendcol
       do jlev = 1, nlev-1
-        overlap_param(jlev, jcol) = cloud%overlap_param(jcol,jlev)
+        overlap_param(jlev, jcol) = cloud_overlap_param(jcol,jlev)
       end do
     end do
     !$OMP END TARGET TEAMS DISTRIBUTE PARALLEL DO
@@ -243,9 +315,9 @@ contains
       ! Loop to compute total cloud cover and the cumulative cloud cover
       ! down to the base of each layer
       do jlev = 1,nlev-1
-        if (single_level%cos_sza(jcol) > 0.0_jprb ) then
+        if (cos_sza_col(jcol) > 0.0_jprb ) then
           ! Convert to "alpha" overlap parameter if necessary
-          if (config%use_beta_overlap) then
+          if (use_beta_overlap) then
             overlap_alpha = beta2alpha(overlap_param(jlev,jcol), &
                   &                     frac(jlev,jcol), frac(jlev+1,jcol))
           else
@@ -263,7 +335,7 @@ contains
     !$OMP TARGET TEAMS DISTRIBUTE PARALLEL DO
     do jcol = istartcol,iendcol
       !Only perform calculation if sun above the horizon
-      if (single_level%cos_sza(jcol) > 0.0_jprb ) then
+      if (cos_sza_col(jcol) > 0.0_jprb ) then
         cum_cloud_cover(1, jcol) = frac(1,jcol)
         cum_product(jcol) = 1.0_jprb - frac(1,jcol)
         do jlev = 1,nlev-1
@@ -276,11 +348,11 @@ contains
           end if
           cum_cloud_cover(jlev+1, jcol) = 1.0_jprb - cum_product(jcol)
         end do
-        flux%cloud_cover_sw(jcol) = cum_cloud_cover(nlev,jcol);
-        if (flux%cloud_cover_sw(jcol) < config%cloud_fraction_threshold) then
+        cloud_cover_sw(jcol) = cum_cloud_cover(nlev,jcol);
+        if (cloud_cover_sw(jcol) < cloud_fraction_threshold) then
           ! Treat column as clear sky: calling function therefore will not
           ! use od_scaling so we don't need to calculate it
-          flux%cloud_cover_sw(jcol) = 0.0_jprb
+          cloud_cover_sw(jcol) = 0.0_jprb
         end if
       end if
     end do
@@ -289,7 +361,7 @@ contains
     !$OMP TARGET TEAMS DISTRIBUTE PARALLEL DO
     do jcol = istartcol,iendcol
       !Only perform calculation if sun above the horizon
-      if (single_level%cos_sza(jcol) > 0.0_jprb .and. flux%cloud_cover_sw(jcol) >= config%cloud_fraction_threshold) then
+      if (cos_sza_col(jcol) > 0.0_jprb .and. cloud_cover_sw(jcol) >= cloud_fraction_threshold) then
         ! Cloud is present: need to calculate od_scaling
         ! Find range of cloudy layers
         ibegin(jcol) = nlev
@@ -315,31 +387,34 @@ contains
        do jg = 1, ng
           ! Do cloudy-sky calculation
           call cloud_generator_omp(jg, ng, nlev, &
-               &  single_level%iseed(jcol) + 0, & ! Workaround for nvhpc-24.1
-               &  config%cloud_fraction_threshold, &
+               &  iseed(jcol) + 0, & ! Workaround for nvhpc-24.1
+               &  cloud_fraction_threshold, &
                &  frac(:,jcol), overlap_param(:,jcol), &
-               &  config%cloud_inhom_decorr_scaling, frac_std(:,jcol), &
-               &  config%pdf_sampler%ncdf, config%pdf_sampler%nfsd, &
-               &  config%pdf_sampler%fsd1, config%pdf_sampler%inv_fsd_interval, &
+               &  cloud_inhom_decorr_scaling, frac_std(:,jcol), &
+               &  ncdf, nfsd, &
+               &  fsd1, inv_fsd_interval, &
                &  sample_val, &
-               &  od_scaling(:,:,jcol), flux%cloud_cover_sw(jcol)+0.0_jprb, & ! Workaround for nvhpc-24.1
+               &  od_scaling(:,:,jcol), cloud_cover_sw(jcol)+0.0_jprb, & ! Workaround for nvhpc-24.1
                &  ibegin(jcol), iend(jcol), &
                &  cum_cloud_cover=cum_cloud_cover(:,jcol), &
                &  pair_cloud_cover=pair_cloud_cover(:,jcol))
        enddo
     enddo
 
-    !$OMP TARGET TEAMS DISTRIBUTE PARALLEL DO COLLAPSE(2) PRIVATE(cos_sza, gamma1, gamma2, gamma3, od_cloud_new, od_total, &
-    !$OMP& ssa_total, g_total, scat_od, jcol, jg, jlev) FIRSTPRIVATE(istartcol, iendcol, ng, nlev) THREAD_LIMIT(512)
+    ! Split the former combined kernel so the always-on clear-sky path is not
+    ! compiled together with cloudy two-stream/adding.
+    ! Revert: restore radiation_mcica_omp_sw.F90.pre_split_l404
+    !$OMP TARGET TEAMS DISTRIBUTE PARALLEL DO COLLAPSE(2) PRIVATE(cos_sza, gamma1, gamma2, gamma3, od_total, &
+    !$OMP& ssa_total, g_total, jcol, jg, jlev) FIRSTPRIVATE(istartcol, iendcol, ng, nlev) THREAD_LIMIT(1024)
     do jcol = istartcol,iendcol
        do jg = 1, ng
           ! Only perform calculation if sun above the horizon
-          if (single_level%cos_sza(jcol) > 0.0_jprb) then
-             cos_sza = single_level%cos_sza(jcol)
+          if (cos_sza_col(jcol) > 0.0_jprb) then
+             cos_sza = cos_sza_col(jcol)
 
              ! Clear-sky calculation - first compute clear-sky reflectance,
              ! transmittance etc at each model level
-             if (.not. config%do_sw_delta_scaling_with_gases) then
+             if (.not. do_sw_delta_scaling_with_gases) then
                 ! Delta-Eddington scaling has already been performed to the
                 ! aerosol part of od, ssa and g
                 call calc_ref_trans_sw_omp(jg, ng, nlev, &
@@ -382,16 +457,32 @@ contains
              end do
              
              ! Store spectral downwelling fluxes at surface
-             flux%sw_dn_diffuse_surf_clear_g(jg,jcol) = flux_dn_diffuse(jg,nlev+1,jcol)
-             flux%sw_dn_direct_surf_clear_g(jg,jcol)  = flux_dn_direct(jg,nlev+1,jcol)
+             sw_dn_diffuse_surf_clear_g(jg,jcol) = flux_dn_diffuse(jg,nlev+1,jcol)
+             sw_dn_direct_surf_clear_g(jg,jcol)  = flux_dn_direct(jg,nlev+1,jcol)
+          else
+             sw_dn_diffuse_surf_g(jg,jcol) = 0.0_jprb
+             sw_dn_direct_surf_g(jg,jcol)  = 0.0_jprb
+             sw_dn_diffuse_surf_clear_g(jg,jcol) = 0.0_jprb
+             sw_dn_direct_surf_clear_g(jg,jcol)  = 0.0_jprb
+          end if ! Sun above horizon
+       end do !loop over spectral bands
+    end do ! Loop over columns
+    !$OMP END TARGET TEAMS DISTRIBUTE PARALLEL DO
 
-             if (flux%cloud_cover_sw(jcol) >= config%cloud_fraction_threshold) then
+    !$OMP TARGET TEAMS DISTRIBUTE PARALLEL DO COLLAPSE(2) PRIVATE(cos_sza, od_cloud_new, od_total, &
+    !$OMP& ssa_total, g_total, scat_od, jcol, jg, jlev) FIRSTPRIVATE(istartcol, iendcol, ng, nlev) THREAD_LIMIT(1024)
+    do jcol = istartcol,iendcol
+       do jg = 1, ng
+          if (cos_sza_col(jcol) > 0.0_jprb) then
+             cos_sza = cos_sza_col(jcol)
+
+             if (cloud_cover_sw(jcol) >= cloud_fraction_threshold) then
                 ! Total-sky calculation
                 do jlev = 1,nlev
                    ! Compute combined gas+aerosol+cloud optical properties
-                   if (frac(jlev,jcol) >= config%cloud_fraction_threshold) then
+                   if (frac(jlev,jcol) >= cloud_fraction_threshold) then
                       od_cloud_new = od_scaling(jg,jlev,jcol) &
-                           &  * od_cloud(config%i_band_from_reordered_g_sw(jg),jlev,jcol)
+                           &  * od_cloud(i_band_from_reordered_g_sw(jg),jlev,jcol)
                       od_total  = od(jg,jlev,jcol) + od_cloud_new
                       ssa_total = 0.0_jprb
                       g_total   = 0.0_jprb
@@ -401,20 +492,20 @@ contains
                       ! od_total*ssa_total == 0 due to underflow
                       if (od_total > 0.0_jprb) then
                          scat_od = ssa(jg,jlev,jcol)*od(jg,jlev,jcol) &
-                              &     + ssa_cloud(config%i_band_from_reordered_g_sw(jg),jlev,jcol) &
+                              &     + ssa_cloud(i_band_from_reordered_g_sw(jg),jlev,jcol) &
                               &     *  od_cloud_new
                          ssa_total = scat_od / od_total
                          if (scat_od > 0.0_jprb) then
                             g_total = (g(jg,jlev,jcol)*ssa(jg,jlev,jcol)*od(jg,jlev,jcol) &
-                                 &     +   g_cloud(config%i_band_from_reordered_g_sw(jg),jlev,jcol) &
-                                 &     * ssa_cloud(config%i_band_from_reordered_g_sw(jg),jlev,jcol) &
+                                 &     +   g_cloud(i_band_from_reordered_g_sw(jg),jlev,jcol) &
+                                 &     * ssa_cloud(i_band_from_reordered_g_sw(jg),jlev,jcol) &
                                  &     *  od_cloud_new) &
                                  &     / scat_od
                          end if
                       end if
                       ! Apply delta-Eddington scaling to the cloud-aerosol-gas
                       ! mixture
-                      if (config%do_sw_delta_scaling_with_gases) then
+                      if (do_sw_delta_scaling_with_gases) then
                          call delta_eddington(od_total, ssa_total, g_total)
                       end if
 
@@ -443,41 +534,37 @@ contains
                      &  flux_up(:,:,jcol), flux_dn_diffuse(:,:,jcol), source=tmp_work_source(:,:,jcol))
                 
                 ! Likewise for surface spectral fluxes
-                flux%sw_dn_diffuse_surf_g(jg,jcol) = flux_dn_diffuse(jg,nlev+1,jcol)
-                flux%sw_dn_direct_surf_g(jg,jcol)  = flux_dn_direct(jg,nlev+1,jcol)
-                flux%sw_dn_diffuse_surf_g(jg,jcol) = flux%cloud_cover_sw(jcol) *flux%sw_dn_diffuse_surf_g(jg,jcol) &
-                     &     + (1.0_jprb - flux%cloud_cover_sw(jcol))*flux%sw_dn_diffuse_surf_clear_g(jg,jcol)
-                flux%sw_dn_direct_surf_g(jg,jcol) = flux%cloud_cover_sw(jcol) *flux%sw_dn_direct_surf_g(jg,jcol) &
-                     &     + (1.0_jprb - flux%cloud_cover_sw(jcol))*flux%sw_dn_direct_surf_clear_g(jg,jcol)
+                sw_dn_diffuse_surf_g(jg,jcol) = flux_dn_diffuse(jg,nlev+1,jcol)
+                sw_dn_direct_surf_g(jg,jcol)  = flux_dn_direct(jg,nlev+1,jcol)
+                sw_dn_diffuse_surf_g(jg,jcol) = cloud_cover_sw(jcol) *sw_dn_diffuse_surf_g(jg,jcol) &
+                     &     + (1.0_jprb - cloud_cover_sw(jcol))*sw_dn_diffuse_surf_clear_g(jg,jcol)
+                sw_dn_direct_surf_g(jg,jcol) = cloud_cover_sw(jcol) *sw_dn_direct_surf_g(jg,jcol) &
+                     &     + (1.0_jprb - cloud_cover_sw(jcol))*sw_dn_direct_surf_clear_g(jg,jcol)
                 
              else
                 ! No cloud in profile and clear-sky fluxes already
                 ! calculated: copy them over
-                flux%sw_dn_diffuse_surf_g(jg,jcol) = flux%sw_dn_diffuse_surf_clear_g(jg,jcol)
-                flux%sw_dn_direct_surf_g(jg,jcol)  = flux%sw_dn_direct_surf_clear_g(jg,jcol)
+                sw_dn_diffuse_surf_g(jg,jcol) = sw_dn_diffuse_surf_clear_g(jg,jcol)
+                sw_dn_direct_surf_g(jg,jcol)  = sw_dn_direct_surf_clear_g(jg,jcol)
 
              end if ! Cloud is present in profile
           else
-             flux%sw_dn_diffuse_surf_g(jg,jcol) = 0.0_jprb
-             flux%sw_dn_direct_surf_g(jg,jcol)  = 0.0_jprb
-             flux%sw_dn_diffuse_surf_clear_g(jg,jcol) = 0.0_jprb
-             flux%sw_dn_direct_surf_clear_g(jg,jcol)  = 0.0_jprb
+             sw_dn_diffuse_surf_g(jg,jcol) = 0.0_jprb
+             sw_dn_direct_surf_g(jg,jcol)  = 0.0_jprb
+             sw_dn_diffuse_surf_clear_g(jg,jcol) = 0.0_jprb
+             sw_dn_direct_surf_clear_g(jg,jcol)  = 0.0_jprb
           end if ! Sun above horizon
        end do !loop over spectral bands
     end do ! Loop over columns
     !$OMP END TARGET TEAMS DISTRIBUTE PARALLEL DO
 
     ! Loop through columns
-    !$OMP TARGET TEAMS DISTRIBUTE PARALLEL DO COLLAPSE(2) PRIVATE(cos_sza, sum_dn_diffuse, sum_dn_direct, sum_up)
-#if defined(__amdflang__)
-    !$OMP TILE SIZES(64,1)
-#endif
+    !$OMP TARGET TEAMS DISTRIBUTE PARALLEL DO COLLAPSE(2) PRIVATE(cos_sza, sum_dn_diffuse, sum_dn_direct, sum_up) THREAD_LIMIT(16)
     do jcol = istartcol,iendcol
        do jlev = 1, nlev+1
 
         ! Only perform calculation if sun above the horizon
-        if (single_level%cos_sza(jcol) > 0.0_jprb) then
-          cos_sza = single_level%cos_sza(jcol)
+        if (cos_sza_col(jcol) > 0.0_jprb) then
 
           ! Sum over g-points to compute and save clear-sky broadband
           ! fluxes
@@ -490,13 +577,13 @@ contains
              sum_dn_direct = sum_dn_direct + flux_dn_direct_clear(jg,jlev,jcol)
              sum_dn_diffuse = sum_dn_diffuse + flux_dn_diffuse_clear(jg,jlev,jcol)
           end do
-          flux%sw_up_clear(jcol,jlev) = sum_up
-          if (allocated(flux%sw_dn_direct_clear)) then
-             flux%sw_dn_direct_clear(jcol,jlev) = sum_dn_direct
+          sw_up_clear(jcol,jlev) = sum_up
+          if (present(sw_dn_direct_clear)) then
+             sw_dn_direct_clear(jcol,jlev) = sum_dn_direct
           end if
-          flux%sw_dn_clear(jcol,jlev) = sum_dn_diffuse + sum_dn_direct
-          
-          if (flux%cloud_cover_sw(jcol) >= config%cloud_fraction_threshold) then
+          sw_dn_clear(jcol,jlev) = sum_dn_diffuse + sum_dn_direct
+
+          if (cloud_cover_sw(jcol) >= cloud_fraction_threshold) then
              ! Store overcast broadband fluxes
              sum_up = 0.0_jprb
              sum_dn_direct = 0.0_jprb
@@ -506,19 +593,15 @@ contains
                 sum_dn_direct = sum_dn_direct + flux_dn_direct(jg,jlev,jcol)
                 sum_dn_diffuse = sum_dn_diffuse + flux_dn_diffuse(jg,jlev,jcol)
              end do
-             flux%sw_up(jcol,jlev) = sum_up
-             if (allocated(flux%sw_dn_direct)) then
-                flux%sw_dn_direct(jcol,jlev) = sum_dn_direct
+             sw_up(jcol,jlev) = sum_up
+             if (present(sw_dn_direct)) then
+                sw_dn_direct(jcol,jlev) = sum_dn_direct
              end if
-             flux%sw_dn(jcol,jlev) = sum_dn_diffuse + sum_dn_direct
-             
+             sw_dn(jcol,jlev) = sum_dn_diffuse + sum_dn_direct
           end if
        end if ! Sun above horizon
       end do ! Loop over columns
     end do
-#if defined(__amdflang__)
-    !$OMP END TILE
-#endif
     !$OMP END TARGET TEAMS DISTRIBUTE PARALLEL DO
 
     ! Loop through columns
@@ -526,42 +609,42 @@ contains
     do jlev = 1, nlev+1
       do jcol = istartcol,iendcol
         ! Only perform calculation if sun above the horizon
-        if (single_level%cos_sza(jcol) > 0.0_jprb) then
-          cos_sza = single_level%cos_sza(jcol)
+        if (cos_sza_col(jcol) > 0.0_jprb) then
+          cos_sza = cos_sza_col(jcol)
 
-          if (flux%cloud_cover_sw(jcol) >= config%cloud_fraction_threshold) then
+          if (cloud_cover_sw(jcol) >= cloud_fraction_threshold) then
             ! Cloudy flux profiles currently assume completely overcast
             ! skies; perform weighted average with clear-sky profile
-            flux%sw_up(jcol,jlev) =  flux%cloud_cover_sw(jcol) *flux%sw_up(jcol,jlev) &
-                &  + (1.0_jprb - flux%cloud_cover_sw(jcol))*flux%sw_up_clear(jcol,jlev)
-            flux%sw_dn(jcol,jlev) =  flux%cloud_cover_sw(jcol) *flux%sw_dn(jcol,jlev) &
-                &  + (1.0_jprb - flux%cloud_cover_sw(jcol))*flux%sw_dn_clear(jcol,jlev)
-            if (allocated(flux%sw_dn_direct)) then
-              flux%sw_dn_direct(jcol,jlev) = flux%cloud_cover_sw(jcol) *flux%sw_dn_direct(jcol,jlev) &
-                  &  + (1.0_jprb - flux%cloud_cover_sw(jcol))*flux%sw_dn_direct_clear(jcol,jlev)
+            sw_up(jcol,jlev) =  cloud_cover_sw(jcol) *sw_up(jcol,jlev) &
+                &  + (1.0_jprb - cloud_cover_sw(jcol))*sw_up_clear(jcol,jlev)
+            sw_dn(jcol,jlev) =  cloud_cover_sw(jcol) *sw_dn(jcol,jlev) &
+                &  + (1.0_jprb - cloud_cover_sw(jcol))*sw_dn_clear(jcol,jlev)
+            if (present(sw_dn_direct)) then
+              sw_dn_direct(jcol,jlev) = cloud_cover_sw(jcol) *sw_dn_direct(jcol,jlev) &
+                  &  + (1.0_jprb - cloud_cover_sw(jcol))*sw_dn_direct_clear(jcol,jlev)
             end if
 
           else
             ! No cloud in profile and clear-sky fluxes already
             ! calculated: copy them over
-            flux%sw_up(jcol,jlev) = flux%sw_up_clear(jcol,jlev)
-            flux%sw_dn(jcol,jlev) = flux%sw_dn_clear(jcol,jlev)
-            if (allocated(flux%sw_dn_direct)) then
-              flux%sw_dn_direct(jcol,jlev) = flux%sw_dn_direct_clear(jcol,jlev)
+            sw_up(jcol,jlev) = sw_up_clear(jcol,jlev)
+            sw_dn(jcol,jlev) = sw_dn_clear(jcol,jlev)
+            if (present(sw_dn_direct)) then
+              sw_dn_direct(jcol,jlev) = sw_dn_direct_clear(jcol,jlev)
             end if
 
           end if ! Cloud is present in profile
         else
           ! Set fluxes to zero if sun is below the horizon
-          flux%sw_up(jcol,jlev) = 0.0_jprb
-          flux%sw_dn(jcol,jlev) = 0.0_jprb
-          if (allocated(flux%sw_dn_direct)) then
-            flux%sw_dn_direct(jcol,jlev) = 0.0_jprb
+          sw_up(jcol,jlev) = 0.0_jprb
+          sw_dn(jcol,jlev) = 0.0_jprb
+          if (present(sw_dn_direct)) then
+            sw_dn_direct(jcol,jlev) = 0.0_jprb
           end if
-          flux%sw_up_clear(jcol,jlev) = 0.0_jprb
-          flux%sw_dn_clear(jcol,jlev) = 0.0_jprb
-          if (allocated(flux%sw_dn_direct_clear)) then
-            flux%sw_dn_direct_clear(jcol,jlev) = 0.0_jprb
+          sw_up_clear(jcol,jlev) = 0.0_jprb
+          sw_dn_clear(jcol,jlev) = 0.0_jprb
+          if (present(sw_dn_direct_clear)) then
+            sw_dn_direct_clear(jcol,jlev) = 0.0_jprb
           end if
         end if ! Sun above horizon
       end do ! Loop over columns
@@ -581,12 +664,7 @@ contains
     !$OMP END TARGET DATA
 #endif
 
-#ifdef HAVE_ROCTX
-    call roctxEndRange
-#endif
+  end subroutine solver_mcica_omp_sw_impl
 
-    if (lhook) call dr_hook('radiation_mcica_omp_sw:solver_mcica_omp_sw',1,hook_handle)
-
-  end subroutine solver_mcica_omp_sw
 
 end module radiation_mcica_omp_sw


### PR DESCRIPTION
The OMPGPU blocked driver produced wrong fluxes whenever ncol was not an exact multiple of nblocksize. The trailing partial block came back all zeros, giving errors of ~248 W/m² on flux_net_lw_clear. Since the default 16960-column input divides evenly by the common block sizes, this stayed hidden until block sizes like 8192 and 4000 were tried.

Two independent causes, both required to be fixed:

- Partial-slice device transfers. The driver used TARGET UPDATE TO/FROM on partial row slices, zrgp(1:il,...). Flang's omptarget mishandles these, so the trailing block's results never made it back to the host.
- Assumed-shape dummies in the McICA solvers. The offload kernels received assumed-shape arrays whose Fortran descriptors the runtime remaps at every target region. On a partial final block the column extent was wrong inside the kernel.

Fixing either one alone still leaves ~200 W/m² errors, so the two commits must land together. The branch also adds the per-block timing needed to quantify any of this.

Each commit shows block size, performance, and correctness.