### PR TITLE
Rename master to main (#39)

### DIFF
--- a/.github/workflows/sync.yaml
+++ b/.github/workflows/sync.yaml
@@ -6,7 +6,7 @@ on:
   # Trigger the workflow on all pushes to the named branches and all tags
   push:
     branches:
-    - 'master'
+    - 'main'
     tags:
     - '**'
 

--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -10,8 +10,7 @@ checks:
   ensure-assignee: {}
   validate-target-branch:
     allowed-branches:
-      - master
-      - develop
+      - main
   assign-reviewers:
     exclude-author: true
     exclude-existing: true


### PR DESCRIPTION
### Description

To align with the policy for ECMWF repositories, rename the default branch from master to main.

To ensure smooth transition, I have already created a "main" branch as a copy of "master". This PR changes the PRTK settings to reflect the renaming in PR checks.

Once merged, open PRs to master need to be redirected to master, then master can be deleted.

### Contributor Declaration

By opening this pull request, I affirm the following:

* All authors agree to the [Contributor License Agreement](https://github.com/ecmwf/codex/blob/main/Legal/contributor_license_agreement.md).
* The code follows the project's coding standards.
* I have performed self-review and added comments where needed.
* I have added or updated tests to verify that my changes are effective and functional.
* I have run all existing tests and confirmed they pass.
 